### PR TITLE
Allow customizing activity

### DIFF
--- a/lily.properties
+++ b/lily.properties
@@ -1,7 +1,9 @@
 # An included configuration file for Lily, used for the instance running in the Iris Discord server.
 
-# Specify the path to this file as the first launch arg if you would like to use it.
+# Specify the path to this file in the CONFIG_FILE field of your .env file if you would like to use it.
 # You may make your own config file elsewhere if you'd rather make your own.
+
+activity = Iris 1.17.1
 
 commands = config crash-report eta indium logs rule sodium starline updatedrivers optifine
 

--- a/src/main/java/net/irisshaders/lilybot/LilyBot.java
+++ b/src/main/java/net/irisshaders/lilybot/LilyBot.java
@@ -59,7 +59,7 @@ public class LilyBot {
         CommandClient builder = new CommandClientBuilder()
                 .setHelpConsumer(null)
                 .setStatus(OnlineStatus.ONLINE)
-                .setActivity(Activity.playing("Iris 1.17.1"))
+                .setActivity(Activity.playing(properties.getProperty("activity")))
                 .setOwnerId(Constants.OWNER)
                 .forceGuildOnly(Constants.GUILD_ID)
                 .build();


### PR DESCRIPTION
Allows customizing the activity Lily is playing in the properties file.

Also updates the comment in that file, because now you specify it in the `.env` file and not as launch argument.