### PR TITLE
Shutdown correctly

### DIFF
--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Shutdown.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Shutdown.java
@@ -73,16 +73,7 @@ public class Shutdown extends SlashCommand {
                     actionLog.sendMessageEmbeds(finalShutdownEmbed).queue();
                     LoggerFactory.getLogger(Shutdown.class).info("Shutting down due to a request from " + buttonClickEventUser.getAsTag() + "!");
 
-                    // Wait for it to send the embed and respond to any other commands. Can be reduced to a lower number if testing allows for it.
-                    try { TimeUnit.SECONDS.sleep(10); } catch (InterruptedException e) { e.printStackTrace(); }
-
-                    jda.shutdownNow();
-                    try {
-                        TimeUnit.SECONDS.sleep(3L);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    System.exit(0);
+                    jda.shutdown();
 
                 }
                 case "no" -> {


### PR DESCRIPTION
The method `shutdownNow` tries to force shutdown, cancelling what's going on. `shutdown` finishes current tasks and then stops.

In my brief testing, it always takes less than 10 seconds for the jvm to stop doing when doing this. And this ensures that all queued tasks have finished, without guessing "it must have finished by this time".

NOTE: For proper testing, you either have to wait around 1,5min from start or use it with #24 (because else all of the commands will be queued and ratelimit will delay shutdown a lot, and may even throw some exceptions).