### PR TITLE
Log Message Edits

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,10 +25,9 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build Artifacts
-        run: ./gradlew build --stacktrace
-#        uses: gradle/gradle-build-action@v2
-#        with:
-#          arguments: build --stacktrace
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --stacktrace
 
       - name: Extract Current Branch name
         shell: bash

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,9 +25,10 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build Artifacts
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build --stacktrace
+        run: ./gradlew build --stacktrace
+#        uses: gradle/gradle-build-action@v2
+#        with:
+#          arguments: build --stacktrace
 
       - name: Extract Current Branch name
         shell: bash

--- a/src/main/kotlin/org/hyacinthbots/lilybot/LilyBot.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/LilyBot.kt
@@ -18,6 +18,7 @@ import org.hyacinthbots.lilybot.extensions.config.GuildLogging
 import org.hyacinthbots.lilybot.extensions.events.LogUploading
 import org.hyacinthbots.lilybot.extensions.events.MemberLogging
 import org.hyacinthbots.lilybot.extensions.events.MessageDelete
+import org.hyacinthbots.lilybot.extensions.events.MessageEdit
 import org.hyacinthbots.lilybot.extensions.events.ThreadInviter
 import org.hyacinthbots.lilybot.extensions.moderation.Report
 import org.hyacinthbots.lilybot.extensions.moderation.TemporaryModeration
@@ -80,6 +81,7 @@ suspend fun main() {
 			add(::LogUploading)
 			add(::MemberLogging)
 			add(::MessageDelete)
+			add(::MessageEdit)
 			add(::ModUtilities)
 			add(::PublicUtilities)
 			add(::Reminders)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/Config.kt
@@ -8,7 +8,8 @@ import kotlinx.serialization.Serializable
  * disable certain configurations.
  *
  * @param guildId The ID of the guild the config is for
- * @param enableMessageLogs If edited and deleted messages should be logged
+ * @param enableMessageDeleteLogs If deleted messages should be logged
+ * @param enableMessageEditLogs If edited messages should be logged
  * @param messageChannel The channel to send message logs to
  * @param enableMemberLogs If users joining or leaving the guild should be logged
  * @param memberLog The channel to send member logs to
@@ -17,7 +18,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LoggingConfigData(
 	val guildId: Snowflake,
-	val enableMessageLogs: Boolean,
+	val enableMessageDeleteLogs: Boolean,
+	val enableMessageEditLogs: Boolean,
 	val messageChannel: Snowflake?,
 	val enableMemberLogs: Boolean,
 	val memberLog: Snowflake?,

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/Migrator.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/Migrator.kt
@@ -75,6 +75,9 @@ object Migrator : KordExKoinComponent {
 	suspend fun migrateConfig() {
 		logger.info { "Starting config database migration" }
 
+		// TODO Remove this line once the migration is done because nc is an absolute clown and got versions out of sync
+		db.configDatabase.dropCollection("configMetaData")
+		// ^
 		var meta = configMetaCollection.get()
 
 		if (meta == null) {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/config/configV1.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/config/configV1.kt
@@ -1,8 +1,20 @@
 package org.hyacinthbots.lilybot.database.migrations.config
 
+import org.hyacinthbots.lilybot.database.entities.LoggingConfigData
 import org.litote.kmongo.coroutine.CoroutineDatabase
+import org.litote.kmongo.exists
+import org.litote.kmongo.setValue
 
-@Suppress("UnusedPrivateMember")
 suspend fun configV1(configDb: CoroutineDatabase) {
-	// Empty until required
+	with(configDb.getCollection<LoggingConfigData>("loggingConfigData")) {
+		updateMany(
+			LoggingConfigData::enableMessageEditLogs exists false,
+			setValue(LoggingConfigData::enableMessageEditLogs, false)
+		)
+	}
+
+	configDb.getCollection<LoggingConfigData>("loggingConfigData").updateMany(
+		"{}",
+		"{\$rename: {enableMessageLogs: \"enableMessageDeleteLogs\"}}"
+	)
 }

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
@@ -306,7 +306,7 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 				respond { content = "You must specify a channel to log members joining and leaving to!" }
 				return@action
 			} else if ((arguments.enableMessageDeleteLogs || arguments.enableMessageEditLogs) && arguments.messageLogs == null) {
-				respond { content = "You must specify a channel to log deleted messages to!" }
+				respond { content = "You must specify a channel to log deleted/edited messages to!" }
 				return@action
 			}
 

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
@@ -305,7 +305,7 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			if (arguments.enableMemberLogging && arguments.memberLog == null) {
 				respond { content = "You must specify a channel to log members joining and leaving to!" }
 				return@action
-			} else if (arguments.enableMessageLogs && arguments.messageLogs == null) {
+			} else if ((arguments.enableMessageDeleteLogs || arguments.enableMessageEditLogs) && arguments.messageLogs == null) {
 				respond { content = "You must specify a channel to log deleted messages to!" }
 				return@action
 			}
@@ -313,8 +313,16 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			suspend fun EmbedBuilder.loggingEmbed() {
 				title = "Configuration: Logging"
 				field {
-					name = "Message Logs"
-					value = if (arguments.enableMessageLogs && arguments.messageLogs?.mention != null) {
+					name = "Message Delete Logs"
+					value = if (arguments.enableMessageDeleteLogs && arguments.messageLogs?.mention != null) {
+						arguments.messageLogs!!.mention
+					} else {
+						"Disabled"
+					}
+				}
+				field {
+					name = "Message Edit Logs"
+					value = if (arguments.enableMessageEditLogs && arguments.messageLogs?.mention != null) {
 						arguments.messageLogs!!.mention
 					} else {
 						"Disabled"
@@ -343,7 +351,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			LoggingConfigCollection().setConfig(
 				LoggingConfigData(
 					guild!!.id,
-					arguments.enableMessageLogs,
+					arguments.enableMessageDeleteLogs,
+					arguments.enableMessageEditLogs,
 					arguments.messageLogs?.id,
 					arguments.enableMemberLogging,
 					arguments.memberLog?.id
@@ -625,9 +634,14 @@ class ModerationArgs : Arguments() {
 }
 
 class LoggingArgs : Arguments() {
-	val enableMessageLogs by boolean {
-		name = "enable-message-logs"
+	val enableMessageDeleteLogs by boolean {
+		name = "enable-delete-logs"
 		description = "Enable logging of message deletions"
+	}
+
+	val enableMessageEditLogs by boolean {
+		name = "enable-edit-logs"
+		description = "Enable logging of message edits"
 	}
 
 	val enableMemberLogging by boolean {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/ConfigOptions.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/ConfigOptions.kt
@@ -27,8 +27,11 @@ enum class ConfigOptions {
 	/** The option that stores whether to log a moderation action publicly. */
 	LOG_PUBLICLY,
 
-	/** The option that stores whether the logging config is enabled or not. */
-	MESSAGE_LOGGING_ENABLED,
+	/** The option that stores whether message delete logging is enabled. */
+	MESSAGE_DELETE_LOGGING_ENABLED,
+
+	/** The option that stores whether message edit logging is enabled. */
+	MESSAGE_EDIT_LOGGING_ENABLED,
 
 	/** The options that stores the message logging channel. */
 	MESSAGE_LOG,

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
@@ -38,7 +38,7 @@ class MessageDelete : Extension() {
 		event<ProxiedMessageDeleteEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				configPresent(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message?.author?.id == kord.selfId
 				}
@@ -57,7 +57,7 @@ class MessageDelete : Extension() {
 		event<UnProxiedMessageDeleteEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				configPresent(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message?.author?.id == kord.selfId ||
 							event.message?.author?.isBot == true

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
@@ -4,14 +4,13 @@ import com.kotlindiscord.kord.extensions.DISCORD_PINK
 import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.event
+import com.kotlindiscord.kord.extensions.modules.extra.pluralkit.api.PKMessage
 import com.kotlindiscord.kord.extensions.modules.extra.pluralkit.events.ProxiedMessageDeleteEvent
 import com.kotlindiscord.kord.extensions.modules.extra.pluralkit.events.UnProxiedMessageDeleteEvent
 import dev.kord.core.behavior.channel.asChannelOf
 import dev.kord.core.behavior.channel.createMessage
-import dev.kord.core.behavior.getChannelOf
-import dev.kord.core.entity.Attachment
+import dev.kord.core.entity.Message
 import dev.kord.core.entity.channel.GuildMessageChannel
-import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.create.embed
 import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
@@ -19,6 +18,8 @@ import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.configPresent
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
+import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
+import org.hyacinthbots.lilybot.utils.trimmedContents
 
 /**
  * The class for logging deletion of messages to the guild message log.
@@ -30,9 +31,9 @@ class MessageDelete : Extension() {
 
 	override suspend fun setup() {
 		/**
-		 * Logs deleted messages in a guild to the message log channel designated in the config for that guild
+		 * Logs proxied deleted messages in a guild to the message log channel designated in the config for that guild
 		 * @author NoComment1105
-		 * @since 2.0
+		 * @see messageDelete
 		 */
 		event<ProxiedMessageDeleteEvent> {
 			check {
@@ -44,58 +45,15 @@ class MessageDelete : Extension() {
 			}
 
 			action {
-				val config = LoggingConfigCollection().getConfig(event.getGuild().id) ?: return@action
-				val messageLog =
-					getLoggingChannelWithPerms(event.getGuild(), config.messageChannel!!, ConfigType.LOGGING)
-						?: return@action
-
-				val originalMessage = event.message
-				val proxiedMessage = event.pkMessage
-				val messageContent = if (originalMessage?.asMessageOrNull() != null) {
-					if (originalMessage.asMessageOrNull().content.length > 1024) {
-						originalMessage.asMessageOrNull().content.substring(0, 1024) + "..."
-					} else {
-						originalMessage.asMessageOrNull().content
-					}
-				} else {
-					null
-				}
-				val messageLocation = event.pkMessage.channel
-				val attachments = event.message?.attachments
-				val images: MutableSet<Attachment> = mutableSetOf()
-				attachments?.forEach { if (it.isImage) images += it }
-
-				messageLog.createMessage {
-					embed {
-						color = DISCORD_PINK
-						author {
-							name = "Message deleted"
-							icon = proxiedMessage.member.avatarUrl
-						}
-						description =
-							"Location: ${event.getGuild().getChannelOf<GuildMessageChannel>(messageLocation).mention}" +
-									"(${event.getGuild().getChannelOf<GuildMessageChannel>(messageLocation).name})"
-						timestamp = Clock.System.now()
-
-						fields(messageContent, attachments)
-
-						field {
-							name = "Message Author:"
-							value = "System Member: ${proxiedMessage.member.name}\n" +
-									"Account: ${event.getGuild().getMember(proxiedMessage.sender).tag} " +
-									event.getGuild().getMember(proxiedMessage.sender).mention
-							inline = true
-						}
-
-						field {
-							name = "Author ID:"
-							value = proxiedMessage.sender.toString()
-						}
-					}
-				}
+				messageDelete(event.getMessage(), event.pkMessage)
 			}
 		}
 
+		/**
+		 * Logs unproxied deleted messages in a guild to the message log channel designated in the config for that guild
+		 * @author NoComment1105
+		 * @see messageDelete
+		 */
 		event<UnProxiedMessageDeleteEvent> {
 			check {
 				anyGuild()
@@ -107,94 +65,78 @@ class MessageDelete : Extension() {
 			}
 
 			action {
-				val config = LoggingConfigCollection().getConfig(event.getGuild().id) ?: return@action
+				messageDelete(event.getMessage(), null)
+			}
+		}
+	}
 
-				val message = event.message
+	/**
+	 * If message logging is enabled, sends an embed describing the message deletion to the guild's message log channel
+	 *
+	 * @param message The deleted message
+	 * @param proxiedMessage Extra data for PluralKit proxied messages
+	 * @author trainb0y
+	 */
+	private suspend fun messageDelete(message: Message, proxiedMessage: PKMessage?) {
+		val guild = message.getGuild()
+		val config = LoggingConfigCollection().getConfig(guild.id) ?: return
+		val messageLog =
+			getLoggingChannelWithPerms(message.getGuild(), config.messageChannel!!, ConfigType.LOGGING)
+				?: return
 
-				val messageLog =
-					getLoggingChannelWithPerms(event.getGuild(), config.messageChannel!!, ConfigType.LOGGING)
-						?: return@action
+		messageLog.createMessage {
+			embed {
+				color = DISCORD_PINK
+				author {
+					name = "Message deleted"
+					icon = proxiedMessage?.member?.avatarUrl ?: message.author?.avatar?.url
+				}
+				description =
+					"Location: ${message.channel.mention}" +
+							"(${message.channel.asChannelOf<GuildMessageChannel>().name})"
+				timestamp = Clock.System.now()
 
-				val messageContent = if (message?.asMessageOrNull() != null) {
-					if (message.asMessageOrNull().content.length > 1024) {
-						message.asMessageOrNull().content.substring(0, 1024) + "..."
-					} else {
-						message.asMessageOrNull().content
+				field {
+					name = "Message contents"
+					value = message.trimmedContents().ifNullOrEmpty { "Failed to retrieve previous message contents" }
+					inline = false
+				}
+
+				if (message.attachments.isNotEmpty()) {
+					field {
+						name = "Attachments"
+						value = message.attachments.map { it.url }.joinToString { "\n" }
+						inline = false
+					}
+				}
+
+				if (proxiedMessage != null) {
+					field {
+						name = "Message Author:"
+						value = "System Member: ${proxiedMessage.member.name}\n" +
+								"Account: ${guild.getMember(proxiedMessage.sender).tag} " +
+								guild.getMember(proxiedMessage.sender).mention
+						inline = true
+					}
+
+					field {
+						name = "Author ID:"
+						value = proxiedMessage.sender.toString()
 					}
 				} else {
-					null
-				}
+					field {
+						name = "Message Author:"
+						value =
+							"${message.author?.tag ?: "Failed to get author of message"} ${message.author?.mention ?: ""}"
+						inline = true
+					}
 
-				message ?: return@action
-
-				val messageLocation = event.channel.asChannelOf<GuildMessageChannel>()
-				val attachments = event.message?.attachments
-				val images: MutableSet<Attachment> = mutableSetOf()
-				attachments?.forEach { if (it.isImage) images += it }
-
-				messageLog.createMessage {
-					embed {
-						color = DISCORD_PINK
-						author {
-							name = "Message deleted"
-							icon = message.author?.avatar?.url
-						}
-						description =
-							"Location: ${messageLocation.mention}" +
-									"(${messageLocation.name})"
-						timestamp = Clock.System.now()
-
-						fields(messageContent, attachments)
-
-						field {
-							name = "Message Author:"
-							value =
-								"${message.author?.tag ?: "Failed to get author of message"} ${message.author?.mention ?: ""}"
-							inline = true
-						}
-
-						field {
-							name = "Author ID:"
-							value = message.author?.id.toString()
-						}
+					field {
+						name = "Author ID:"
+						value = message.author?.id.toString()
 					}
 				}
 			}
-		}
-	}
-}
-
-/**
- * Adds the common fields to a deleted message embed.
- *
- * @param messageContent The content of the message.
- * @param attachments The attachments of the message.
- *
- * @author NoComment1105
- * @since 3.6.0
- */
-private fun EmbedBuilder.fields(messageContent: String?, attachments: Set<Attachment>?) {
-	field {
-		name = "Message contents"
-		value =
-			if (messageContent.isNullOrEmpty()) {
-				"Failed to retrieve message contents"
-			} else {
-				messageContent
-			}
-		inline = false
-	}
-	if (!attachments.isNullOrEmpty()) {
-		val attachmentUrls = StringBuilder()
-		attachments.forEach {
-			attachmentUrls.append(
-				it.url + "\n"
-			)
-		}
-		field {
-			name = "Attachments"
-			value = attachmentUrls.trim().toString()
-			inline = false
 		}
 	}
 }

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
@@ -33,7 +33,7 @@ class MessageDelete : Extension() {
 		/**
 		 * Logs proxied deleted messages in a guild to the message log channel designated in the config for that guild
 		 * @author NoComment1105
-		 * @see messageDelete
+		 * @see onMessageDelete
 		 */
 		event<ProxiedMessageDeleteEvent> {
 			check {
@@ -45,14 +45,14 @@ class MessageDelete : Extension() {
 			}
 
 			action {
-				messageDelete(event.getMessage(), event.pkMessage)
+				onMessageDelete(event.getMessage(), event.pkMessage)
 			}
 		}
 
 		/**
-		 * Logs unproxied deleted messages in a guild to the message log channel designated in the config for that guild
+		 * Logs unproxied deleted messages in a guild to the message log channel designated in the config for that guild.
 		 * @author NoComment1105
-		 * @see messageDelete
+		 * @see onMessageDelete
 		 */
 		event<UnProxiedMessageDeleteEvent> {
 			check {
@@ -65,19 +65,19 @@ class MessageDelete : Extension() {
 			}
 
 			action {
-				messageDelete(event.getMessage(), null)
+				onMessageDelete(event.getMessage(), null)
 			}
 		}
 	}
 
 	/**
-	 * If message logging is enabled, sends an embed describing the message deletion to the guild's message log channel
+	 * If message logging is enabled, sends an embed describing the message deletion to the guild's message log channel.
 	 *
 	 * @param message The deleted message
 	 * @param proxiedMessage Extra data for PluralKit proxied messages
 	 * @author trainb0y
 	 */
-	private suspend fun messageDelete(message: Message, proxiedMessage: PKMessage?) {
+	private suspend fun onMessageDelete(message: Message, proxiedMessage: PKMessage?) {
 		val guild = message.getGuild()
 		val config = LoggingConfigCollection().getConfig(guild.id) ?: return
 		val messageLog =

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
@@ -37,7 +37,7 @@ class MessageEdit : Extension() {
 		event<UnProxiedMessageUpdateEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				configPresent(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message.asMessage().author?.id == kord.selfId
 				}
@@ -55,7 +55,7 @@ class MessageEdit : Extension() {
 		event<ProxiedMessageUpdateEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				configPresent(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message.asMessage().author?.id == kord.selfId
 				}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
@@ -1,0 +1,140 @@
+package org.hyacinthbots.lilybot.extensions.events
+
+import com.kotlindiscord.kord.extensions.DISCORD_YELLOW
+import com.kotlindiscord.kord.extensions.checks.anyGuild
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.event
+import com.kotlindiscord.kord.extensions.modules.extra.pluralkit.api.PKMessage
+import com.kotlindiscord.kord.extensions.modules.extra.pluralkit.events.ProxiedMessageUpdateEvent
+import com.kotlindiscord.kord.extensions.modules.extra.pluralkit.events.UnProxiedMessageUpdateEvent
+import dev.kord.core.behavior.channel.asChannelOf
+import dev.kord.core.behavior.channel.createMessage
+import dev.kord.core.entity.Message
+import dev.kord.core.entity.channel.GuildMessageChannel
+import dev.kord.rest.builder.message.create.embed
+import kotlinx.datetime.Clock
+import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
+import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
+import org.hyacinthbots.lilybot.extensions.config.ConfigType
+import org.hyacinthbots.lilybot.utils.configPresent
+import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
+import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
+import org.hyacinthbots.lilybot.utils.trimmedContents
+
+/**
+ * The class for logging editing of messages to the guild message log.
+ */
+class MessageEdit : Extension() {
+	override val name = "message-edit"
+
+	override suspend fun setup() {
+		/**
+		 * Logs edited messages to the message log channel.
+		 * @see messageEdit
+		 * @author trainb0y
+		 */
+		event<UnProxiedMessageUpdateEvent> {
+			check {
+				anyGuild()
+				configPresent(ConfigOptions.MESSAGE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				failIf {
+					event.message.asMessage().author?.id == kord.selfId
+				}
+			}
+			action {
+				messageEdit(event.getMessage(), event.old, null)
+			}
+		}
+
+		/**
+		 * Logs proxied edited messages to the message log channel.
+		 * @see messageEdit
+		 * @author trainb0y
+		 */
+		event<ProxiedMessageUpdateEvent> {
+			check {
+				anyGuild()
+				configPresent(ConfigOptions.MESSAGE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				failIf {
+					event.message.asMessage().author?.id == kord.selfId
+				}
+			}
+			action {
+				messageEdit(event.getMessage(), event.old, event.pkMessage)
+			}
+		}
+	}
+
+	/**
+	 * If message logging is enabled, sends an embed describing the message edit to the guild's message log channel
+	 *
+	 * @param message The current message
+	 * @param old The original message
+	 * @param proxiedMessage Extra data for PluralKit proxied messages
+	 * @author trainb0y
+	 */
+	private suspend fun messageEdit(message: Message, old: Message?, proxiedMessage: PKMessage?) {
+		val guild = message.getGuild()
+		val config = LoggingConfigCollection().getConfig(guild.id) ?: return
+		val messageLog =
+			getLoggingChannelWithPerms(guild, config.messageChannel!!, ConfigType.LOGGING)
+				?: return
+
+		messageLog.createMessage {
+			embed {
+				color = DISCORD_YELLOW
+				author {
+					name = "Message Edited"
+					icon = proxiedMessage?.member?.avatarUrl ?: message.author?.avatar?.url
+				}
+				description =
+					"Location: ${message.channel.mention}" +
+							"(${message.channel.asChannelOf<GuildMessageChannel>().name})"
+				timestamp = Clock.System.now()
+
+				field {
+					name = "Previous contents"
+					value = old?.trimmedContents().ifNullOrEmpty { "Failed to retrieve previous message contents" }
+					inline = false
+				}
+				field {
+					name = "New contents"
+					value = message.trimmedContents().ifNullOrEmpty { "Failed to retrieve new message contents" }
+					inline = false
+				}
+
+				if (message.attachments.isNotEmpty()) {
+					field {
+						name = "Attachments"
+						value = message.attachments.map { it.url }.joinToString { "\n" }
+						inline = false
+					}
+				}
+				if (proxiedMessage != null) {
+					field {
+						name = "Message Author:"
+						value = "System Member: ${proxiedMessage.member.name}\n" +
+								"Account: ${guild.getMember(proxiedMessage.sender).tag} " +
+								guild.getMember(proxiedMessage.sender).mention
+						inline = true
+					}
+					field {
+						name = "Author ID:"
+						value = proxiedMessage.sender.toString()
+					}
+				} else {
+					field {
+						name = "Message Author:"
+						value =
+							"${message.author?.tag ?: "Failed to get author of message"} ${message.author?.mention ?: ""}"
+						inline = true
+					}
+					field {
+						name = "Author ID:"
+						value = message.author?.id.toString()
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
@@ -23,6 +23,7 @@ import org.hyacinthbots.lilybot.utils.trimmedContents
 
 /**
  * The class for logging editing of messages to the guild message log.
+ * @since 4.1.0
  */
 class MessageEdit : Extension() {
 	override val name = "message-edit"
@@ -30,7 +31,7 @@ class MessageEdit : Extension() {
 	override suspend fun setup() {
 		/**
 		 * Logs edited messages to the message log channel.
-		 * @see messageEdit
+		 * @see onMessageEdit
 		 * @author trainb0y
 		 */
 		event<UnProxiedMessageUpdateEvent> {
@@ -42,13 +43,13 @@ class MessageEdit : Extension() {
 				}
 			}
 			action {
-				messageEdit(event.getMessage(), event.old, null)
+				onMessageEdit(event.getMessage(), event.old, null)
 			}
 		}
 
 		/**
 		 * Logs proxied edited messages to the message log channel.
-		 * @see messageEdit
+		 * @see onMessageEdit
 		 * @author trainb0y
 		 */
 		event<ProxiedMessageUpdateEvent> {
@@ -60,20 +61,20 @@ class MessageEdit : Extension() {
 				}
 			}
 			action {
-				messageEdit(event.getMessage(), event.old, event.pkMessage)
+				onMessageEdit(event.getMessage(), event.old, event.pkMessage)
 			}
 		}
 	}
 
 	/**
-	 * If message logging is enabled, sends an embed describing the message edit to the guild's message log channel
+	 * If message logging is enabled, sends an embed describing the message edit to the guild's message log channel.
 	 *
 	 * @param message The current message
 	 * @param old The original message
 	 * @param proxiedMessage Extra data for PluralKit proxied messages
 	 * @author trainb0y
 	 */
-	private suspend fun messageEdit(message: Message, old: Message?, proxiedMessage: PKMessage?) {
+	private suspend fun onMessageEdit(message: Message, old: Message?, proxiedMessage: PKMessage?) {
 		val guild = message.getGuild()
 		val config = LoggingConfigCollection().getConfig(guild.id) ?: return
 		val messageLog =

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -21,6 +21,7 @@ import dev.kord.core.behavior.getChannelOfOrNull
 import dev.kord.core.behavior.interaction.response.FollowupPermittingInteractionResponseBehavior
 import dev.kord.core.behavior.interaction.response.createEphemeralFollowup
 import dev.kord.core.entity.Guild
+import dev.kord.core.entity.Message
 import dev.kord.core.entity.User
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.entity.channel.NewsChannel
@@ -552,4 +553,28 @@ suspend inline fun getChannelOrFirstUsable(configOption: ConfigOptions, guild: G
 	} else {
 		guild.asGuild().getSystemChannel() ?: getFirstUsableChannel(guild.asGuild())
 	}
+}
+
+/**
+ * Utility to get a string or a default value.
+ * Basically String.ifEmpty but works with nullable strings
+ *
+ * @return This, or defaultValue if this is null or empty
+ * @author trainb0y
+ * @see String.ifEmpty
+ */
+fun String?.ifNullOrEmpty(defaultValue: () -> String): String =
+	if (this.isNullOrEmpty()) defaultValue()
+	else this
+
+/**
+ * Get this message's contents, trimmed to 1024 characters.
+ * If the message exceeds that length, it will be truncated and an ellipsis appended.
+ * @author trainb0y
+ */
+fun Message?.trimmedContents(): String? {
+	this ?: return null
+	return if (this.content.length > 1024) {
+		this.content.substring(0, 1020) + " ..."
+	} else this.content
 }

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -561,16 +561,21 @@ suspend inline fun getChannelOrFirstUsable(configOption: ConfigOptions, guild: G
  *
  * @return This, or defaultValue if this is null or empty
  * @author trainb0y
+ * @since 4.1.0
  * @see String.ifEmpty
  */
 fun String?.ifNullOrEmpty(defaultValue: () -> String): String =
-	if (this.isNullOrEmpty()) defaultValue()
-	else this
+	if (this.isNullOrEmpty()) {
+		defaultValue()
+	} else {
+		this
+	}
 
 /**
  * Get this message's contents, trimmed to 1024 characters.
  * If the message exceeds that length, it will be truncated and an ellipsis appended.
  * @author trainb0y
+ * @since 4.1.0
  */
 fun Message?.trimmedContents(): String? {
 	this ?: return null

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -171,13 +171,26 @@ suspend inline fun CheckContext<*>.configPresent(vararg configOptions: ConfigOpt
 				}
 			}
 
-			ConfigOptions.MESSAGE_LOGGING_ENABLED -> {
+			ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED -> {
 				val loggingConfig = LoggingConfigCollection().getConfig(guildFor(event)!!.id)
 				if (loggingConfig == null) {
 					fail("Unable to access logging config for this guild! Please inform a member of staff.")
 					break
-				} else if (!loggingConfig.enableMessageLogs) {
-					fail("Message logging is disabled for this guild!")
+				} else if (!loggingConfig.enableMessageDeleteLogs) {
+					fail("Message delete logging is disabled for this guild!")
+					break
+				} else {
+					pass()
+				}
+			}
+
+			ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED -> {
+				val loggingConfig = LoggingConfigCollection().getConfig(guildFor(event)!!.id)
+				if (loggingConfig == null) {
+					fail("Unable to access logging config for this guild! Please inform a member of staff.")
+					break
+				} else if (!loggingConfig.enableMessageEditLogs) {
+					fail("Message edit logging is disabled for this guild!")
 					break
 				} else {
 					pass()


### PR DESCRIPTION
### Linked Issues
https://github.com/IrisShaders/LilyBot/issues/197

### Proposed Changes
This PR adds message edit logging, similar to the current message delete logging.
https://github.com/IrisShaders/LilyBot/issues/197 mentions the feature being "opt-in" but as if I understand correctly there is a configuration system overhaul ongoing, so I didn't try to add that.

![image](https://user-images.githubusercontent.com/66213737/180611552-7a214aef-b41d-441f-9787-c5174b207ff1.png)

### DISREGARD THESE, SEE BELOW
A few points of note:
- I think the edit embeds should have a different color from the delete embeds, but I'm not sure what.
- I added a couple functions to `_Utils.kt` so as to avoid duplicating large amounts of code from `MessageDelete.kt` but I'm not exactly sure where the proper place to put them is.
- Was there a reason attachment urls are handled the way they are currently? As far as I can tell `message.attachments.map { it.url }` has the same result as the current url parsing.
- I feel like `Message.trimmedContents()` would be better off as an extension value than an extension function, but as I saw no other extension values, I didn't make it one.
- I'm not sure if message editing needs any special handling for PluralKit. I didn't test with it so I'm not sure how this behaves.

