### PR TITLE
Granular optional config

### DIFF
--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
@@ -39,7 +39,6 @@ import org.hyacinthbots.lilybot.database.entities.ModerationConfigData
 import org.hyacinthbots.lilybot.database.entities.SupportConfigData
 import org.hyacinthbots.lilybot.database.entities.UtilityConfigData
 import org.hyacinthbots.lilybot.utils.canPingRole
-import org.hyacinthbots.lilybot.utils.getFirstUsableChannel
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import kotlin.time.Duration.Companion.seconds
 
@@ -172,7 +171,14 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			}
 
 			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
-				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			if (utilityLog == null) {
+				ackEphemeral()
+				respondEphemeral {
+					content = "Consider setting a utility config to log changes to configurations."
+				}
+				return@action
+			}
 
 			utilityLog.createMessage {
 				embed {
@@ -265,7 +271,13 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			)
 
 			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
-				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			if (utilityLog == null) {
+				respond {
+					content = "Consider setting a utility config to log changes to configurations."
+				}
+				return@action
+			}
 
 			utilityLog.createMessage {
 				embed {
@@ -352,7 +364,13 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			)
 
 			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
-				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			if (utilityLog == null) {
+				respond {
+					content = "Consider setting a utility config to log changes to configurations."
+				}
+				return@action
+			}
 
 			utilityLog.createMessage {
 				embed {
@@ -422,7 +440,13 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			)
 
 			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
-				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			if (utilityLog == null) {
+				respond {
+					content = "Consider setting a utility config to log changes to configurations."
+				}
+				return@action
+			}
 
 			utilityLog.createMessage {
 				embed {
@@ -444,7 +468,13 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 		action {
 			suspend fun logClear() {
 				val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
-					?: getFirstUsableChannel(guild!!) ?: return
+
+				if (utilityLog == null) {
+					respond {
+						content = "Consider setting a utility config to log changes to configurations."
+					}
+					return
+				}
 
 				utilityLog.createMessage {
 					embed {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
@@ -19,16 +19,12 @@ import com.kotlindiscord.kord.extensions.modules.unsafe.types.respondEphemeral
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.utils.waitFor
 import dev.kord.common.entity.Permission
-import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.TextInputStyle
-import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.behavior.interaction.modal
 import dev.kord.core.behavior.interaction.respondEphemeral
-import dev.kord.core.behavior.interaction.response.FollowupPermittingInteractionResponseBehavior
 import dev.kord.core.behavior.interaction.response.createEphemeralFollowup
 import dev.kord.core.behavior.interaction.response.respond
-import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.interaction.ModalSubmitInteractionCreateEvent
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.create.embed
@@ -175,30 +171,15 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 				)
 			}
 
-			if (ModerationConfigCollection().getConfig(guild!!.id) == null) {
-				getLoggingChannelWithPerms(
-					guild!!.asGuild(),
-					guild!!.asGuild().getSystemChannel()?.id ?: getFirstUsableChannel(guild!!.asGuild())!!.id,
-					ConfigType.MODERATION,
-					interactionResponse
-				)
-			} else {
-				getLoggingChannelWithPerms(
-					guild!!.asGuild(),
-					ModerationConfigCollection().getConfig(guild!!.id)!!.channel!!,
-					ConfigType.MODERATION,
-					interactionResponse
-				)
-			}?.createMessage {
+			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			utilityLog.createMessage {
 				embed {
 					supportEmbed()
 					field {
 						name = "Message"
 						value = SupportConfigCollection().getConfig(guild!!.id)?.message ?: "default"
-					}
-					ModerationConfigCollection().getConfig(guild!!.id) ?: run {
-						description = "Consider setting the moderation configuration to receive configuration " +
-								"updates where you want them!"
 					}
 				}
 			}
@@ -273,15 +254,6 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 				}
 			}
 
-			if (getLoggingChannelWithPerms(
-					guild!!.asGuild(),
-					arguments.modActionLog?.id,
-					ConfigType.MODERATION
-				)?.id != arguments.modActionLog?.id
-			) {
-				return@action
-			}
-
 			ModerationConfigCollection().setConfig(
 				ModerationConfigData(
 					guild!!.id,
@@ -292,11 +264,10 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 				)
 			)
 
-			checkChannel(
-				guild,
-				arguments.modActionLog?.id,
-				interactionResponse
-			)?.createMessage {
+			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			utilityLog.createMessage {
 				embed {
 					moderationEmbed()
 				}
@@ -380,17 +351,12 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 				)
 			)
 
-			checkChannel(
-				guild,
-				ModerationConfigCollection().getConfig(guild!!.id)?.channel,
-				interactionResponse
-			)?.createMessage {
+			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			utilityLog.createMessage {
 				embed {
 					loggingEmbed()
-					ModerationConfigCollection().getConfig(guild!!.id) ?: run {
-						description = "Consider setting the moderation configuration to receive configuration " +
-								"updates where you want them!"
-					}
 				}
 			}
 		}
@@ -455,17 +421,12 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 				)
 			)
 
-			checkChannel(
-				guild,
-				ModerationConfigCollection().getConfig(guild!!.id)?.channel,
-				interactionResponse
-			)?.createMessage {
+			val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+				?: getFirstUsableChannel(guild!!) ?: return@action
+
+			utilityLog.createMessage {
 				embed {
 					utilityEmbed()
-					ModerationConfigCollection().getConfig(guild!!.id) ?: run {
-						description = "Consider setting the moderation configuration to receive configuration " +
-								"updates where you want them!"
-					}
 				}
 			}
 		}
@@ -482,19 +443,14 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 
 		action {
 			suspend fun logClear() {
-				checkChannel(
-					guild,
-					ModerationConfigCollection().getConfig(guild!!.id)?.channel,
-					interactionResponse
-				)?.createMessage {
+				val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+					?: getFirstUsableChannel(guild!!) ?: return
+
+				utilityLog.createMessage {
 					embed {
 						title = "Configuration Cleared: ${arguments.config[0]}${
 							arguments.config.substring(1, arguments.config.length).lowercase()
 						}"
-						ModerationConfigCollection().getConfig(guild!!.id) ?: run {
-							description = "Consider setting the moderation configuration to receive configuration " +
-									"updates where you want them!"
-						}
 						footer {
 							text = "Config cleared by ${user.asUser().tag}"
 							icon = user.asUser().avatar?.url
@@ -677,8 +633,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 								name = "Message delete logs"
 								value = if (config.enableMessageDeleteLogs) {
 									"Enabled\n" +
-											"${config.messageChannel?.let { guild!!.getChannelOrNull(it)?.mention }} " +
-											"${config.messageChannel?.let { guild!!.getChannelOrNull(it)?.name }}"
+											"${guild!!.getChannel(config.messageChannel!!).mention} " +
+											"${guild!!.getChannel(config.messageChannel).name }}"
 								} else {
 									"Disabled"
 								}
@@ -687,8 +643,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 								name = "Message edit logs"
 								value = if (config.enableMessageEditLogs) {
 									"Enabled\n" +
-											"${config.messageChannel?.let { guild!!.getChannelOrNull(it)?.mention }} " +
-											"${config.messageChannel?.let { guild!!.getChannelOrNull(it)?.name }}"
+											"${guild!!.getChannel(config.messageChannel!!).mention }} " +
+											"${guild!!.getChannel(config.messageChannel).name }}"
 								} else {
 									"Disabled"
 								}
@@ -697,8 +653,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 								name = "Member logs"
 								value = if (config.enableMemberLogs) {
 									"Enabled\n" +
-											"${config.memberLog?.let { guild!!.getChannelOrNull(it)?.mention }} " +
-											"${config.memberLog?.let { guild!!.getChannelOrNull(it)?.name }} "
+											"${guild!!.getChannel(config.memberLog!!).mention }} " +
+											"${guild!!.getChannel(config.memberLog).name }} "
 								} else {
 									"Disabled"
 								}
@@ -885,41 +841,4 @@ class ViewArgs : Arguments() {
 			"utility" to ConfigType.UTILITY.name,
 		)
 	}
-}
-
-/**
- * Checks the moderation config and returns where the message needs to be sent.
- *
- * @param guild The guild the event is in
- * @param channelIdToCheck The id of the channel to check
- * @param interactionResponse The response for the interaction
- * @return the channel to send the message to
- * @since 4.0.0
- * @author NoComment
- */
-suspend inline fun checkChannel(
-	guild: GuildBehavior?,
-	channelIdToCheck: Snowflake?,
-	interactionResponse: FollowupPermittingInteractionResponseBehavior
-): GuildMessageChannel? {
-	val toReturn: GuildMessageChannel?
-	if (ModerationConfigCollection().getConfig(guild!!.id) == null ||
-		!ModerationConfigCollection().getConfig(guild.id)!!.enabled ||
-		channelIdToCheck == null
-	) {
-		toReturn = getLoggingChannelWithPerms(
-			guild.asGuild(),
-			guild.asGuild().getSystemChannel()?.id ?: getFirstUsableChannel(guild.asGuild())!!.id,
-			ConfigType.MODERATION,
-			interactionResponse
-		)
-	} else {
-		toReturn = getLoggingChannelWithPerms(
-			guild.asGuild(),
-			channelIdToCheck,
-			ConfigType.MODERATION,
-			interactionResponse
-		)
-	}
-	return toReturn
 }

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/LogUploading.kt
@@ -51,7 +51,7 @@ import org.hyacinthbots.lilybot.database.entities.SupportConfigData
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.utils.botHasChannelPerms
 import org.hyacinthbots.lilybot.utils.configIsUsable
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.util.zip.GZIPInputStream
@@ -83,9 +83,7 @@ class LogUploading : Extension() {
 					event.message.author.isNullOrBot()
 					event.message.getChannelOrNull() !is MessageChannel
 				}
-				requireConfigs(
-					ConfigOptions.LOG_UPLOADS_ENABLED
-				)
+				requiredConfigs(ConfigOptions.LOG_UPLOADS_ENABLED)
 
 				// I hate NullPointerExceptions. This is to prevent a null pointer exception if the message is a Pk one.
 				if (channelFor(event) == null) return@check

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MemberLogging.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MemberLogging.kt
@@ -9,9 +9,7 @@ import dev.kord.core.behavior.channel.createEmbed
 import dev.kord.core.event.guild.MemberJoinEvent
 import dev.kord.core.event.guild.MemberLeaveEvent
 import kotlinx.datetime.Clock
-import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.getMemberCount
 import org.hyacinthbots.lilybot.utils.requiredConfigs
@@ -34,9 +32,7 @@ class MemberLogging : Extension() {
 				failIf { event.member.id == kord.selfId }
 			}
 			action {
-				val config = LoggingConfigCollection().getConfig(event.guildId)!!
-				val memberLog = getLoggingChannelWithPerms(event.getGuild(), config.memberLog!!, ConfigType.LOGGING)
-					?: return@action
+				val memberLog = getLoggingChannelWithPerms(ConfigOptions.MEMBER_LOG, event.guild) ?: return@action
 
 				memberLog.createEmbed {
 					author {
@@ -70,9 +66,7 @@ class MemberLogging : Extension() {
 				failIf { event.user.id == kord.selfId }
 			}
 			action {
-				val config = LoggingConfigCollection().getConfig(event.guildId)!!
-				val memberLog = getLoggingChannelWithPerms(event.getGuild(), config.memberLog!!, ConfigType.LOGGING)
-					?: return@action
+				val memberLog = getLoggingChannelWithPerms(ConfigOptions.MEMBER_LOG, event.guild) ?: return@action
 
 				memberLog.createEmbed {
 					author {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MemberLogging.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MemberLogging.kt
@@ -14,7 +14,7 @@ import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.getMemberCount
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 
 /**
  * Logs members joining and leaving a guild to the member log channel designated in the config for that guild.
@@ -30,7 +30,7 @@ class MemberLogging : Extension() {
 		event<MemberJoinEvent> {
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
+				requiredConfigs(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
 				failIf { event.member.id == kord.selfId }
 			}
 			action {
@@ -66,7 +66,7 @@ class MemberLogging : Extension() {
 		event<MemberLeaveEvent> {
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
+				requiredConfigs(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
 				failIf { event.user.id == kord.selfId }
 			}
 			action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MemberLogging.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MemberLogging.kt
@@ -12,9 +12,9 @@ import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
-import org.hyacinthbots.lilybot.utils.configPresent
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.getMemberCount
+import org.hyacinthbots.lilybot.utils.requireConfigs
 
 /**
  * Logs members joining and leaving a guild to the member log channel designated in the config for that guild.
@@ -30,7 +30,7 @@ class MemberLogging : Extension() {
 		event<MemberJoinEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
+				requireConfigs(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
 				failIf { event.member.id == kord.selfId }
 			}
 			action {
@@ -66,7 +66,7 @@ class MemberLogging : Extension() {
 		event<MemberLeaveEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
+				requireConfigs(ConfigOptions.MEMBER_LOGGING_ENABLED, ConfigOptions.MEMBER_LOG)
 				failIf { event.user.id == kord.selfId }
 			}
 			action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
@@ -12,9 +12,7 @@ import dev.kord.core.behavior.channel.createEmbed
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.channel.GuildMessageChannel
 import kotlinx.datetime.Clock
-import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.attachmentsAndProxiedMessageInfo
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
@@ -79,14 +77,12 @@ class MessageDelete : Extension() {
 	 */
 	private suspend fun onMessageDelete(message: Message, proxiedMessage: PKMessage?) {
 		val guild = message.getGuild()
-		val config = LoggingConfigCollection().getConfig(guild.id) ?: return
-		val messageLog =
-			getLoggingChannelWithPerms(message.getGuild(), config.messageChannel!!, ConfigType.LOGGING)
-				?: return
 
 		if (message.content.startsWith("pk;e", 0, true)) {
 			return
 		}
+
+		val messageLog = getLoggingChannelWithPerms(ConfigOptions.MESSAGE_LOG, guild) ?: return
 
 		messageLog.createEmbed {
 			author {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
@@ -18,7 +18,7 @@ import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.attachmentsAndProxiedMessageInfo
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 import org.hyacinthbots.lilybot.utils.trimmedContents
 
 /**
@@ -38,7 +38,7 @@ class MessageDelete : Extension() {
 		event<ProxiedMessageDeleteEvent> {
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requiredConfigs(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message?.author?.id == kord.selfId
 				}
@@ -57,7 +57,7 @@ class MessageDelete : Extension() {
 		event<UnProxiedMessageDeleteEvent> {
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requiredConfigs(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message?.author?.id == kord.selfId ||
 							event.message?.author?.isBot == true

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageDelete.kt
@@ -16,9 +16,9 @@ import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.attachmentsAndProxiedMessageInfo
-import org.hyacinthbots.lilybot.utils.configPresent
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
+import org.hyacinthbots.lilybot.utils.requireConfigs
 import org.hyacinthbots.lilybot.utils.trimmedContents
 
 /**
@@ -38,7 +38,7 @@ class MessageDelete : Extension() {
 		event<ProxiedMessageDeleteEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requireConfigs(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message?.author?.id == kord.selfId
 				}
@@ -57,7 +57,7 @@ class MessageDelete : Extension() {
 		event<UnProxiedMessageDeleteEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requireConfigs(ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message?.author?.id == kord.selfId ||
 							event.message?.author?.isBot == true

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
@@ -18,7 +18,7 @@ import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.attachmentsAndProxiedMessageInfo
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 import org.hyacinthbots.lilybot.utils.trimmedContents
 
 /**
@@ -37,7 +37,7 @@ class MessageEdit : Extension() {
 		event<UnProxiedMessageUpdateEvent> {
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requiredConfigs(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message.asMessage().author?.id == kord.selfId
 				}
@@ -55,7 +55,7 @@ class MessageEdit : Extension() {
 		event<ProxiedMessageUpdateEvent> {
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requiredConfigs(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message.asMessage().author?.id == kord.selfId
 				}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
@@ -12,9 +12,7 @@ import dev.kord.core.behavior.channel.createEmbed
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.channel.GuildMessageChannel
 import kotlinx.datetime.Clock
-import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.attachmentsAndProxiedMessageInfo
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
@@ -76,10 +74,8 @@ class MessageEdit : Extension() {
 	 */
 	private suspend fun onMessageEdit(message: Message, old: Message?, proxiedMessage: PKMessage?) {
 		val guild = message.getGuild()
-		val config = LoggingConfigCollection().getConfig(guild.id) ?: return
-		val messageLog =
-			getLoggingChannelWithPerms(guild, config.messageChannel!!, ConfigType.LOGGING)
-				?: return
+
+		val messageLog = getLoggingChannelWithPerms(ConfigOptions.MEMBER_LOG, guild) ?: return
 
 		messageLog.createEmbed {
 			color = DISCORD_YELLOW

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/MessageEdit.kt
@@ -16,9 +16,9 @@ import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.attachmentsAndProxiedMessageInfo
-import org.hyacinthbots.lilybot.utils.configPresent
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.ifNullOrEmpty
+import org.hyacinthbots.lilybot.utils.requireConfigs
 import org.hyacinthbots.lilybot.utils.trimmedContents
 
 /**
@@ -37,7 +37,7 @@ class MessageEdit : Extension() {
 		event<UnProxiedMessageUpdateEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requireConfigs(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message.asMessage().author?.id == kord.selfId
 				}
@@ -55,7 +55,7 @@ class MessageEdit : Extension() {
 		event<ProxiedMessageUpdateEvent> {
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
+				requireConfigs(ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED, ConfigOptions.MESSAGE_LOG)
 				failIf {
 					event.message.asMessage().author?.id == kord.selfId
 				}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/ThreadInviter.kt
@@ -38,7 +38,7 @@ import org.hyacinthbots.lilybot.database.collections.ThreadsCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 import kotlin.time.Duration.Companion.seconds
 
 class ThreadInviter : Extension() {
@@ -63,7 +63,7 @@ class ThreadInviter : Extension() {
 			 */
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
+				requiredConfigs(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
 				failIf {
 					event.message.type == MessageType.ChatInputCommand ||
 							event.message.type == MessageType.ThreadCreated ||
@@ -171,7 +171,7 @@ class ThreadInviter : Extension() {
 			 */
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
+				requiredConfigs(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
 				failIf {
 					event.message.type == MessageType.ChatInputCommand ||
 							event.message.type == MessageType.ThreadCreated ||
@@ -281,7 +281,7 @@ class ThreadInviter : Extension() {
 					event.channel.ownerId == kord.selfId ||
 							event.channel.member != null
 				}
-				requireConfigs(
+				requiredConfigs(
 					ConfigOptions.SUPPORT_ENABLED,
 					ConfigOptions.SUPPORT_CHANNEL,
 					ConfigOptions.SUPPORT_ROLE,

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/ThreadInviter.kt
@@ -36,7 +36,6 @@ import org.hyacinthbots.lilybot.database.collections.ModerationConfigCollection
 import org.hyacinthbots.lilybot.database.collections.SupportConfigCollection
 import org.hyacinthbots.lilybot.database.collections.ThreadsCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.requiredConfigs
 import kotlin.time.Duration.Companion.seconds
@@ -95,8 +94,7 @@ class ThreadInviter : Extension() {
 					return@action
 				}
 
-				val supportChannel =
-					getLoggingChannelWithPerms(event.getGuild(), config.channel, ConfigType.SUPPORT) ?: return@action
+				val supportChannel = getLoggingChannelWithPerms(ConfigOptions.SUPPORT_CHANNEL, guild) ?: return@action
 
 				if (textChannel != supportChannel) return@action
 
@@ -197,9 +195,8 @@ class ThreadInviter : Extension() {
 				var existingUserThread: TextChannelThread? = null
 				val textChannel = event.message.getChannel().asChannelOf<TextChannel>()
 				val guild = event.getGuild()
-				val supportChannel =
-					getLoggingChannelWithPerms(event.getGuild(), config.channel!!, ConfigType.SUPPORT)
-						?: return@action
+
+				val supportChannel = getLoggingChannelWithPerms(ConfigOptions.SUPPORT_CHANNEL, guild) ?: return@action
 
 				if (textChannel != supportChannel) return@action
 

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/ThreadInviter.kt
@@ -37,13 +37,15 @@ import org.hyacinthbots.lilybot.database.collections.SupportConfigCollection
 import org.hyacinthbots.lilybot.database.collections.ThreadsCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
-import org.hyacinthbots.lilybot.utils.configPresent
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
+import org.hyacinthbots.lilybot.utils.requireConfigs
 import kotlin.time.Duration.Companion.seconds
 
 class ThreadInviter : Extension() {
 	override val name = "thread-inviter"
 
+	// note: the requireConfigs checks in this file are not perfect,
+	// but will be fully replaced with the thread inviting rewrite so it's ok
 	override suspend fun setup() {
 		/**
 		 * Thread inviting system for Support Channels
@@ -61,7 +63,7 @@ class ThreadInviter : Extension() {
 			 */
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
+				requireConfigs(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
 				failIf {
 					event.message.type == MessageType.ChatInputCommand ||
 							event.message.type == MessageType.ThreadCreated ||
@@ -169,7 +171,7 @@ class ThreadInviter : Extension() {
 			 */
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
+				requireConfigs(ConfigOptions.SUPPORT_ENABLED, ConfigOptions.SUPPORT_CHANNEL, ConfigOptions.SUPPORT_ROLE)
 				failIf {
 					event.message.type == MessageType.ChatInputCommand ||
 							event.message.type == MessageType.ThreadCreated ||
@@ -279,7 +281,7 @@ class ThreadInviter : Extension() {
 					event.channel.ownerId == kord.selfId ||
 							event.channel.member != null
 				}
-				configPresent(
+				requireConfigs(
 					ConfigOptions.SUPPORT_ENABLED,
 					ConfigOptions.SUPPORT_CHANNEL,
 					ConfigOptions.SUPPORT_ROLE,

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/Report.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/Report.kt
@@ -43,7 +43,7 @@ import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.ModerationConfigCollection
 import org.hyacinthbots.lilybot.database.entities.ModerationConfigData
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -74,7 +74,7 @@ suspend inline fun Report.reportMessageCommand() = unsafeMessageCommand {
 
 	check {
 		anyGuild()
-		requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
+		requiredConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
 	}
 
 	action {
@@ -132,7 +132,7 @@ suspend inline fun Report.reportSlashCommand() = unsafeSlashCommand(::ManualRepo
 
 	check {
 		anyGuild()
-		requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
+		requiredConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
 	}
 
 	action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/Report.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/Report.kt
@@ -43,7 +43,7 @@ import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.ModerationConfigCollection
 import org.hyacinthbots.lilybot.database.entities.ModerationConfigData
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.utils.configPresent
+import org.hyacinthbots.lilybot.utils.requireConfigs
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -74,7 +74,7 @@ suspend inline fun Report.reportMessageCommand() = unsafeMessageCommand {
 
 	check {
 		anyGuild()
-		configPresent(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
+		requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
 	}
 
 	action {
@@ -132,7 +132,7 @@ suspend inline fun Report.reportSlashCommand() = unsafeSlashCommand(::ManualRepo
 
 	check {
 		anyGuild()
-		configPresent(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
+		requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.MODERATOR_ROLE, ConfigOptions.ACTION_LOG)
 	}
 
 	action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -52,7 +52,7 @@ import org.hyacinthbots.lilybot.utils.configIsUsable
 import org.hyacinthbots.lilybot.utils.dmNotificationStatusEmbedField
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.isBotOrModerator
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 import java.lang.Integer.min
 import kotlin.time.Duration
 
@@ -78,7 +78,7 @@ class TemporaryModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.ManageMessages)
 				requireBotPermissions(Permission.ManageMessages)
 				botHasChannelPerms(Permissions(Permission.ManageMessages))
@@ -141,7 +141,7 @@ class TemporaryModeration : Extension() {
 			check {
 				anyGuild()
 				// todo this code doesn't actually hard require action log and needs a refactor to make it optional
-				requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
 				hasPermission(Permission.ModerateMembers)
 				requireBotPermissions(Permission.ModerateMembers)
 			}
@@ -303,7 +303,7 @@ class TemporaryModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.ModerateMembers)
 				requireBotPermissions(Permission.ModerateMembers)
 			}
@@ -376,7 +376,7 @@ class TemporaryModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.ModerateMembers)
 				requireBotPermissions(Permission.ModerateMembers)
 			}
@@ -470,7 +470,7 @@ class TemporaryModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.ModerateMembers)
 				requireBotPermissions(Permission.ModerateMembers)
 			}
@@ -530,7 +530,7 @@ class TemporaryModeration : Extension() {
 
 				check {
 					anyGuild()
-					requireConfigs(
+					requiredConfigs(
 						ConfigOptions.MODERATION_ENABLED
 					)
 					hasPermission(Permission.ModerateMembers)
@@ -598,7 +598,7 @@ class TemporaryModeration : Extension() {
 
 				check {
 					anyGuild()
-					requireConfigs(
+					requiredConfigs(
 						ConfigOptions.MODERATION_ENABLED
 					)
 					hasPermission(Permission.ModerateMembers)
@@ -663,7 +663,7 @@ class TemporaryModeration : Extension() {
 
 				check {
 					anyGuild()
-					requireConfigs(
+					requiredConfigs(
 						ConfigOptions.MODERATION_ENABLED
 					)
 					hasPermission(Permission.ModerateMembers)
@@ -736,7 +736,7 @@ class TemporaryModeration : Extension() {
 
 				check {
 					anyGuild()
-					requireConfigs(
+					requiredConfigs(
 						ConfigOptions.MODERATION_ENABLED
 					)
 					hasPermission(Permission.ModerateMembers)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TerminalModeration.kt
@@ -31,9 +31,7 @@ import kotlinx.datetime.TimeZone
 import mu.KotlinLogging
 import org.hyacinthbots.lilybot.database.collections.ModerationConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.baseModerationEmbed
-import org.hyacinthbots.lilybot.utils.configIsUsable
 import org.hyacinthbots.lilybot.utils.dmNotificationStatusEmbedField
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.isBotOrModerator
@@ -67,15 +65,6 @@ class TerminalModeration : Extension() {
 			}
 
 			action {
-				val config = ModerationConfigCollection().getConfig(guild!!.id)!!
-				val actionLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						config.channel!!,
-						ConfigType.MODERATION,
-						interactionResponse
-					)
-						?: return@action
 				val userArg = arguments.userArgument
 
 				// Clarify the user is not a bot or moderator
@@ -115,6 +104,7 @@ class TerminalModeration : Extension() {
 					content = "Banned a user"
 				}
 
+				val config = ModerationConfigCollection().getConfig(guild!!.id) ?: return@action
 				if (config.publicLogging != null && config.publicLogging == true) {
 					channel.createEmbed {
 						title = "Banned a user"
@@ -123,7 +113,7 @@ class TerminalModeration : Extension() {
 					}
 				}
 
-				if (!configIsUsable(ConfigOptions.ACTION_LOG, guild!!.id)) return@action
+				val actionLog = getLoggingChannelWithPerms(ConfigOptions.ACTION_LOG, this.getGuild()!!) ?: return@action
 				actionLog.createEmbed {
 					title = "Banned a user"
 					description = "${userArg.mention} has been banned!"
@@ -157,15 +147,6 @@ class TerminalModeration : Extension() {
 			}
 
 			action {
-				val config = ModerationConfigCollection().getConfig(guild!!.id)!!
-				val actionLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						config.channel!!,
-						ConfigType.MODERATION,
-						interactionResponse
-					)
-						?: return@action
 				val userArg = arguments.userArgument
 				// Get all the bans into a list
 				val bans = guild!!.bans.toList().map { it.userId }
@@ -183,7 +164,7 @@ class TerminalModeration : Extension() {
 					content = "Unbanned user"
 				}
 
-				if (!configIsUsable(ConfigOptions.ACTION_LOG, guild!!.id)) return@action
+				val actionLog = getLoggingChannelWithPerms(ConfigOptions.ACTION_LOG, this.getGuild()!!) ?: return@action
 				actionLog.createEmbed {
 					title = "Unbanned a user"
 					description = "${userArg.mention} has been unbanned!\n${userArg.id} (${userArg.tag})"
@@ -218,15 +199,6 @@ class TerminalModeration : Extension() {
 			}
 
 			action {
-				val config = ModerationConfigCollection().getConfig(guild!!.id)!!
-				val actionLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						config.channel!!,
-						ConfigType.MODERATION,
-						interactionResponse
-					)
-						?: return@action
 				val userArg = arguments.userArgument
 
 				isBotOrModerator(userArg, "soft-ban") ?: return@action
@@ -266,6 +238,7 @@ class TerminalModeration : Extension() {
 					content = "Soft-Banned User"
 				}
 
+				val config = ModerationConfigCollection().getConfig(guild!!.id) ?: return@action
 				if (config.publicLogging != null && config.publicLogging == true) {
 					channel.createEmbed {
 						title = "Soft-Banned a user"
@@ -276,7 +249,7 @@ class TerminalModeration : Extension() {
 				// Unban the user, as you're supposed to in soft-ban
 				guild?.unban(userArg.id)
 
-				if (!configIsUsable(ConfigOptions.ACTION_LOG, guild!!.id)) return@action
+				val actionLog = getLoggingChannelWithPerms(ConfigOptions.ACTION_LOG, this.getGuild()!!) ?: return@action
 				actionLog.createEmbed {
 					title = "Soft-Banned a user"
 					description = "${userArg.mention} has been soft-banned!"
@@ -310,15 +283,6 @@ class TerminalModeration : Extension() {
 			}
 
 			action {
-				val config = ModerationConfigCollection().getConfig(guild!!.id)!!
-				val actionLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						config.channel!!,
-						ConfigType.MODERATION,
-						interactionResponse
-					)
-						?: return@action
 				val userArg = arguments.userArgument
 
 				// Clarify the user isn't a bot or a moderator
@@ -348,6 +312,7 @@ class TerminalModeration : Extension() {
 					content = "Kicked User"
 				}
 
+				val config = ModerationConfigCollection().getConfig(guild!!.id) ?: return@action
 				if (config.publicLogging != null && config.publicLogging == true) {
 					channel.createEmbed {
 						title = "Kicked a user"
@@ -355,7 +320,7 @@ class TerminalModeration : Extension() {
 					}
 				}
 
-				if (!configIsUsable(ConfigOptions.ACTION_LOG, guild!!.id)) return@action
+				val actionLog = getLoggingChannelWithPerms(ConfigOptions.ACTION_LOG, this.getGuild()!!) ?: return@action
 				actionLog.createEmbed {
 					title = "Kicked a user"
 					description = "${userArg.mention} has been kicked!"

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TerminalModeration.kt
@@ -37,7 +37,7 @@ import org.hyacinthbots.lilybot.utils.configIsUsable
 import org.hyacinthbots.lilybot.utils.dmNotificationStatusEmbedField
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.isBotOrModerator
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 
 /**
  * The class for permanent moderation actions, such as ban and kick.
@@ -61,7 +61,7 @@ class TerminalModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.BanMembers)
 				requireBotPermissions(Permission.BanMembers, Permission.ManageMessages)
 			}
@@ -151,7 +151,7 @@ class TerminalModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.BanMembers)
 				requireBotPermissions(Permission.BanMembers)
 			}
@@ -212,7 +212,7 @@ class TerminalModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.BanMembers)
 				requireBotPermissions(Permission.BanMembers, Permission.ManageMessages)
 			}
@@ -304,7 +304,7 @@ class TerminalModeration : Extension() {
 
 			check {
 				anyGuild()
-				requireConfigs(ConfigOptions.MODERATION_ENABLED)
+				requiredConfigs(ConfigOptions.MODERATION_ENABLED)
 				hasPermission(Permission.KickMembers)
 				requireBotPermissions(Permission.KickMembers)
 			}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/GalleryChannel.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/GalleryChannel.kt
@@ -23,9 +23,7 @@ import dev.kord.rest.builder.message.create.embed
 import kotlinx.coroutines.delay
 import org.hyacinthbots.lilybot.database.collections.GalleryChannelCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.botHasChannelPerms
-import org.hyacinthbots.lilybot.utils.getChannelOrFirstUsable
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 
 /**
@@ -61,15 +59,6 @@ class GalleryChannel : Extension() {
 				}
 
 				action {
-					val utilityLog =
-						getLoggingChannelWithPerms(
-							guild!!.asGuild(),
-							getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-							ConfigType.UTILITY,
-							interactionResponse
-						)
-							?: return@action
-
 					GalleryChannelCollection().getChannels(guildFor(event)!!.id).forEach {
 						if (channel.asChannel().id == it.channelId) {
 							respond {
@@ -85,6 +74,8 @@ class GalleryChannel : Extension() {
 						content = "Set channel as gallery channel."
 					}
 
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
 					utilityLog.createEmbed {
 						title = "New Gallery channel"
 						description = "${channel.mention} was added as a Gallery channel"
@@ -112,15 +103,6 @@ class GalleryChannel : Extension() {
 				}
 
 				action {
-					val utilityLog =
-						getLoggingChannelWithPerms(
-							guild!!.asGuild(),
-							getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-							ConfigType.UTILITY,
-							interactionResponse
-						)
-							?: return@action
-
 					var channelFound = false
 
 					GalleryChannelCollection().getChannels(guildFor(event)!!.id).forEach {
@@ -135,6 +117,8 @@ class GalleryChannel : Extension() {
 							content = "Unset channel as gallery channel."
 						}
 
+						val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+							?: return@action
 						utilityLog.createEmbed {
 							title = "Removed Gallery channel"
 							description = "${channel.mention} was removed as a Gallery channel"

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
@@ -71,9 +71,10 @@ import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.TEST_GUILD_ID
 import org.hyacinthbots.lilybot.utils.botHasChannelPerms
-import org.hyacinthbots.lilybot.utils.configPresent
+import org.hyacinthbots.lilybot.utils.configIsUsable
 import org.hyacinthbots.lilybot.utils.getChannelOrFirstUsable
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
+import org.hyacinthbots.lilybot.utils.requireConfigs
 import org.hyacinthbots.lilybot.utils.updateDefaultPresence
 import kotlin.time.Duration.Companion.seconds
 
@@ -98,18 +99,17 @@ class ModUtilities : Extension() {
 
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
 				hasPermission(Permission.ModerateMembers)
 				requireBotPermissions(Permission.SendMessages, Permission.EmbedLinks)
 				botHasChannelPerms(Permissions(Permission.SendMessages, Permission.EmbedLinks))
 			}
 			action {
-				val config = ModerationConfigCollection().getConfig(guild!!.id)!!
-				val actionLog =
+				val config = UtilityConfigCollection().getConfig(guild!!.id)!!
+				val utilityLog =
 					getLoggingChannelWithPerms(
 						guild!!.asGuild(),
-						config.channel!!,
-						ConfigType.MODERATION,
+						config.utilityLogChannel!!,
+						ConfigType.UTILITY,
 						interactionResponse
 					)
 						?: return@action
@@ -149,7 +149,8 @@ class ModUtilities : Extension() {
 
 				respond { content = "Message sent." }
 
-				actionLog.createMessage {
+				if (!configIsUsable(ConfigOptions.UTILITY_LOG, guild!!.id)) return@action
+				utilityLog.createMessage {
 					embed {
 						title = "Say command used"
 						description = "```${arguments.message}```"
@@ -377,7 +378,7 @@ class ModUtilities : Extension() {
 
 				check {
 					hasPermission(Permission.Administrator)
-					configPresent(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
+					requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
 				}
 
 				action {
@@ -414,7 +415,7 @@ class ModUtilities : Extension() {
 
 				check {
 					hasPermission(Permission.Administrator)
-					configPresent(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
+					requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
 				}
 
 				action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
@@ -74,7 +74,7 @@ import org.hyacinthbots.lilybot.utils.botHasChannelPerms
 import org.hyacinthbots.lilybot.utils.configIsUsable
 import org.hyacinthbots.lilybot.utils.getChannelOrFirstUsable
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 import org.hyacinthbots.lilybot.utils.updateDefaultPresence
 import kotlin.time.Duration.Companion.seconds
 
@@ -378,7 +378,7 @@ class ModUtilities : Extension() {
 
 				check {
 					hasPermission(Permission.Administrator)
-					requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
+					requiredConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
 				}
 
 				action {
@@ -415,7 +415,7 @@ class ModUtilities : Extension() {
 
 				check {
 					hasPermission(Permission.Administrator)
-					requireConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
+					requiredConfigs(ConfigOptions.MODERATION_ENABLED, ConfigOptions.ACTION_LOG)
 				}
 
 				action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
@@ -68,11 +68,8 @@ import org.hyacinthbots.lilybot.database.collections.ThreadsCollection
 import org.hyacinthbots.lilybot.database.collections.UtilityConfigCollection
 import org.hyacinthbots.lilybot.database.collections.WarnCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.TEST_GUILD_ID
 import org.hyacinthbots.lilybot.utils.botHasChannelPerms
-import org.hyacinthbots.lilybot.utils.configIsUsable
-import org.hyacinthbots.lilybot.utils.getChannelOrFirstUsable
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.requiredConfigs
 import org.hyacinthbots.lilybot.utils.updateDefaultPresence
@@ -104,16 +101,6 @@ class ModUtilities : Extension() {
 				botHasChannelPerms(Permissions(Permission.SendMessages, Permission.EmbedLinks))
 			}
 			action {
-				val config = UtilityConfigCollection().getConfig(guild!!.id)!!
-				val utilityLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						config.utilityLogChannel!!,
-						ConfigType.UTILITY,
-						interactionResponse
-					)
-						?: return@action
-
 				val targetChannel: GuildMessageChannel?
 				try {
 					targetChannel =
@@ -149,7 +136,7 @@ class ModUtilities : Extension() {
 
 				respond { content = "Message sent." }
 
-				if (!configIsUsable(ConfigOptions.UTILITY_LOG, guild!!.id)) return@action
+				val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!) ?: return@action
 				utilityLog.createMessage {
 					embed {
 						title = "Say command used"
@@ -213,16 +200,6 @@ class ModUtilities : Extension() {
 				} else {
 					channel
 				}
-
-				val utilityLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-						ConfigType.UTILITY,
-						interactionResponse
-					)
-						?: return@action
-
 				val message: Message
 
 				try {
@@ -262,6 +239,8 @@ class ModUtilities : Extension() {
 
 					respond { content = "Message edited" }
 
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
 					utilityLog.createMessage {
 						embed {
 							title = "Say message edited"
@@ -312,6 +291,8 @@ class ModUtilities : Extension() {
 
 					respond { content = "Embed updated" }
 
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
 					utilityLog.createMessage {
 						embed {
 							title = "Say message edited"
@@ -425,19 +406,11 @@ class ModUtilities : Extension() {
 					updateDefaultPresence()
 					val guilds = this@ephemeralSlashCommand.kord.guilds.toList().size
 
-					val config = ModerationConfigCollection().getConfig(guild!!.id)!!
-					val actionLog =
-						getLoggingChannelWithPerms(
-							guild!!.asGuild(),
-							config.channel!!,
-							ConfigType.MODERATION,
-							interactionResponse
-						)
-							?: return@action
-
 					respond { content = "Presence set to default" }
 
-					actionLog.createEmbed {
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
+					utilityLog.createEmbed {
 						title = "Presence changed"
 						description = "Lily's presence has been set to default."
 						field {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/PublicUtilities.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/PublicUtilities.kt
@@ -29,7 +29,7 @@ import dev.kord.rest.request.KtorRequestException
 import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.UtilityConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.utils.requireConfigs
+import org.hyacinthbots.lilybot.utils.requiredConfigs
 
 /**
  * This class contains a few utility commands that can be used by the public in guilds, or that are often seen by the
@@ -85,7 +85,7 @@ class PublicUtilities : Extension() {
 
 				check {
 					anyGuild()
-					requireConfigs(ConfigOptions.UTILITY_LOG)
+					requiredConfigs(ConfigOptions.UTILITY_LOG)
 				}
 
 				action {
@@ -293,7 +293,7 @@ class PublicUtilities : Extension() {
 
 				check {
 					anyGuild()
-					requireConfigs(ConfigOptions.UTILITY_LOG)
+					requiredConfigs(ConfigOptions.UTILITY_LOG)
 				}
 
 				action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/PublicUtilities.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/PublicUtilities.kt
@@ -29,7 +29,7 @@ import dev.kord.rest.request.KtorRequestException
 import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.UtilityConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.utils.configPresent
+import org.hyacinthbots.lilybot.utils.requireConfigs
 
 /**
  * This class contains a few utility commands that can be used by the public in guilds, or that are often seen by the
@@ -85,7 +85,7 @@ class PublicUtilities : Extension() {
 
 				check {
 					anyGuild()
-					configPresent(ConfigOptions.UTILITY_LOG)
+					requireConfigs(ConfigOptions.UTILITY_LOG)
 				}
 
 				action {
@@ -293,7 +293,7 @@ class PublicUtilities : Extension() {
 
 				check {
 					anyGuild()
-					configPresent(ConfigOptions.UTILITY_LOG)
+					requireConfigs(ConfigOptions.UTILITY_LOG)
 				}
 
 				action {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/RoleMenu.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/RoleMenu.kt
@@ -39,9 +39,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 import org.hyacinthbots.lilybot.database.collections.RoleMenuCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.botHasChannelPerms
-import org.hyacinthbots.lilybot.utils.getChannelOrFirstUsable
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 import org.hyacinthbots.lilybot.utils.utilsLogger
 
@@ -119,14 +117,8 @@ class RoleMenu : Extension() {
 						mutableListOf(arguments.initialRole.id)
 					)
 
-					val utilityLog =
-						getLoggingChannelWithPerms(
-							guild!!.asGuild(),
-							getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-							ConfigType.UTILITY,
-							interactionResponse
-						)
-							?: return@action
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
 
 					utilityLog.createMessage {
 						embed {
@@ -216,14 +208,8 @@ class RoleMenu : Extension() {
 						data.roles
 					)
 
-					val utilityLog =
-						getLoggingChannelWithPerms(
-							guild!!.asGuild(),
-							getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-							ConfigType.UTILITY,
-							interactionResponse
-						)
-							?: return@action
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
 					utilityLog.createMessage {
 						embed {
 							title = "Role Added to Role Menu"
@@ -285,15 +271,9 @@ class RoleMenu : Extension() {
 					}
 
 					RoleMenuCollection().removeRoleFromMenu(menuMessage!!.id, arguments.role.id)
-					val utilityLog =
-						getLoggingChannelWithPerms(
-							guild!!.asGuild(),
-							getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-							ConfigType.UTILITY,
-							interactionResponse
-						)
-							?: return@action
 
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
 					utilityLog.createMessage {
 						embed {
 							title = "Role Removed from Role Menu"
@@ -392,15 +372,8 @@ class RoleMenu : Extension() {
 						roles
 					)
 
-					val utilityLog =
-						getLoggingChannelWithPerms(
-							guild!!.asGuild(),
-							getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-							ConfigType.UTILITY,
-							interactionResponse
-						)
-							?: return@action
-
+					val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!)
+						?: return@action
 					utilityLog.createMessage {
 						embed {
 							title = "Pronoun Role Menu Created"

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Tags.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Tags.kt
@@ -34,7 +34,7 @@ import org.hyacinthbots.lilybot.database.collections.UtilityConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
 import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.botHasChannelPerms
-import org.hyacinthbots.lilybot.utils.configPresent
+import org.hyacinthbots.lilybot.utils.configIsUsable
 import org.hyacinthbots.lilybot.utils.getChannelOrFirstUsable
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 
@@ -365,7 +365,6 @@ class Tags : Extension() {
 
 			check {
 				anyGuild()
-				configPresent(ConfigOptions.UTILITY_LOG)
 				hasPermission(Permission.ModerateMembers)
 				requireBotPermissions(Permission.SendMessages, Permission.EmbedLinks)
 				botHasChannelPerms(Permissions(Permission.SendMessages, Permission.EmbedLinks))
@@ -410,53 +409,52 @@ class Tags : Extension() {
 					arguments.newAppearance ?: originalAppearance
 				)
 
-				utilityLog.createMessage {
-					embed {
-						title = "Tag Edited"
-						description = "The tag `${arguments.tagName}` was edited"
-						field {
-							name = "Name"
-							value = if (arguments.newName.isNullOrEmpty()) {
-								originalName
-							} else {
-								"$originalName -> ${arguments.newName!!}"
-							}
-						}
-						field {
-							name = "Title"
-							value = if (arguments.newTitle.isNullOrEmpty()) {
-								originalTitle
-							} else {
-								"${arguments.newTitle} -> ${arguments.newTitle!!}"
-							}
-						}
-						field {
-							name = "Value"
-							value = if (arguments.newValue.isNullOrEmpty()) {
-								originalValue
-							} else {
-								"$originalValue -> ${arguments.newValue!!}"
-							}
-						}
-						field {
-							name = "Tag appearance"
-							value = if (arguments.newAppearance.isNullOrEmpty()) {
-								originalAppearance
-							} else {
-								"$originalAppearance -> ${arguments.newAppearance}"
-							}
-						}
-						footer {
-							text = "Edited by ${user.asUser().tag}"
-							icon = user.asUser().avatar?.url
-						}
-						timestamp = Clock.System.now()
-						color = DISCORD_YELLOW
-					}
-				}
-
 				respond {
 					content = "Tag edited!"
+				}
+
+				if (!configIsUsable(ConfigOptions.UTILITY_LOG, guild!!.id)) return@action
+				utilityLog.createEmbed {
+					title = "Tag Edited"
+					description = "The tag `${arguments.tagName}` was edited"
+					field {
+						name = "Name"
+						value = if (arguments.newName.isNullOrEmpty()) {
+							originalName
+						} else {
+							"$originalName -> ${arguments.newName!!}"
+						}
+					}
+					field {
+						name = "Title"
+						value = if (arguments.newTitle.isNullOrEmpty()) {
+							originalTitle
+						} else {
+							"${arguments.newTitle} -> ${arguments.newTitle!!}"
+						}
+					}
+					field {
+						name = "Value"
+						value = if (arguments.newValue.isNullOrEmpty()) {
+							originalValue
+						} else {
+							"$originalValue -> ${arguments.newValue!!}"
+						}
+					}
+					field {
+						name = "Tag appearance"
+						value = if (arguments.newAppearance.isNullOrEmpty()) {
+							originalAppearance
+						} else {
+							"$originalAppearance -> ${arguments.newAppearance}"
+						}
+					}
+					footer {
+						text = "Edited by ${user.asUser().tag}"
+						icon = user.asUser().avatar?.url
+					}
+					timestamp = Clock.System.now()
+					color = DISCORD_YELLOW
 				}
 			}
 		}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Tags.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Tags.kt
@@ -32,10 +32,7 @@ import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.TagsCollection
 import org.hyacinthbots.lilybot.database.collections.UtilityConfigCollection
 import org.hyacinthbots.lilybot.extensions.config.ConfigOptions
-import org.hyacinthbots.lilybot.extensions.config.ConfigType
 import org.hyacinthbots.lilybot.utils.botHasChannelPerms
-import org.hyacinthbots.lilybot.utils.configIsUsable
-import org.hyacinthbots.lilybot.utils.getChannelOrFirstUsable
 import org.hyacinthbots.lilybot.utils.getLoggingChannelWithPerms
 
 /**
@@ -246,15 +243,6 @@ class Tags : Extension() {
 			}
 
 			action {
-				val utilityLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-						ConfigType.UTILITY,
-						interactionResponse
-					)
-						?: return@action
-
 				if (TagsCollection().getTag(guild!!.id, arguments.tagName) != null) {
 					respond { content = "A tag with that name already exists in this guild." }
 					return@action
@@ -276,6 +264,7 @@ class Tags : Extension() {
 					arguments.tagAppearance
 				)
 
+				val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!) ?: return@action
 				utilityLog.createEmbed {
 					title = "Tag created!"
 					description = "The tag `${arguments.tagName}` has been created"
@@ -333,17 +322,9 @@ class Tags : Extension() {
 					return@action
 				}
 
-				val utilityLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-						ConfigType.UTILITY,
-						interactionResponse
-					)
-						?: return@action
-
 				TagsCollection().removeTag(guild!!.id, arguments.tagName)
 
+				val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!) ?: return@action
 				utilityLog.createEmbed {
 					title = "Tag deleted!"
 					description = "The tag ${arguments.tagName} was deleted"
@@ -371,15 +352,6 @@ class Tags : Extension() {
 			}
 
 			action {
-				val utilityLog =
-					getLoggingChannelWithPerms(
-						guild!!.asGuild(),
-						getChannelOrFirstUsable(ConfigOptions.UTILITY_LOG, guild)?.id,
-						ConfigType.UTILITY,
-						interactionResponse
-					)
-						?: return@action
-
 				if (TagsCollection().getTag(guild!!.id, arguments.tagName) == null) {
 					respond { content = "Unable to find tag `${arguments.tagName}`! Does this tag exist?" }
 					return@action
@@ -413,7 +385,7 @@ class Tags : Extension() {
 					content = "Tag edited!"
 				}
 
-				if (!configIsUsable(ConfigOptions.UTILITY_LOG, guild!!.id)) return@action
+				val utilityLog = getLoggingChannelWithPerms(ConfigOptions.UTILITY_LOG, this.getGuild()!!) ?: return@action
 				utilityLog.createEmbed {
 					title = "Tag Edited"
 					description = "The tag `${arguments.tagName}` was edited"

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -68,7 +68,7 @@ internal val utilsLogger = KotlinLogging.logger("Checks Logger")
  * @author NoComment1105
  * @since 3.2.0
  */
-suspend inline fun CheckContext<*>.configPresent(vararg configOptions: ConfigOptions) {
+suspend inline fun CheckContext<*>.requireConfigs(vararg configOptions: ConfigOptions) {
 	if (!passed) {
 		return
 	}
@@ -264,6 +264,80 @@ suspend inline fun CheckContext<*>.configPresent(vararg configOptions: ConfigOpt
 					pass()
 				}
 			}
+		}
+	}
+}
+
+suspend inline fun configIsUsable(option: ConfigOptions, guildId: Snowflake): Boolean {
+	when (option) {
+		ConfigOptions.SUPPORT_ENABLED -> {
+			val supportConfig = SupportConfigCollection().getConfig(guildId) ?: return false
+			return supportConfig.enabled
+		}
+
+		ConfigOptions.SUPPORT_CHANNEL -> {
+			val supportConfig = SupportConfigCollection().getConfig(guildId) ?: return false
+			return supportConfig.channel != null
+		}
+
+		ConfigOptions.SUPPORT_ROLE -> {
+			val supportConfig = SupportConfigCollection().getConfig(guildId) ?: return false
+			return supportConfig.role != null
+		}
+
+		ConfigOptions.MODERATION_ENABLED -> {
+			val moderationConfig = ModerationConfigCollection().getConfig(guildId) ?: return false
+			return moderationConfig.enabled
+		}
+
+		ConfigOptions.MODERATOR_ROLE -> {
+			val moderationConfig = ModerationConfigCollection().getConfig(guildId) ?: return false
+			return moderationConfig.role != null
+		}
+
+		ConfigOptions.ACTION_LOG -> {
+			val moderationConfig = ModerationConfigCollection().getConfig(guildId) ?: return false
+			return moderationConfig.channel != null
+		}
+
+		ConfigOptions.LOG_PUBLICLY -> {
+			val moderationConfig = ModerationConfigCollection().getConfig(guildId) ?: return false
+			return moderationConfig.publicLogging != null
+		}
+
+		ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED -> {
+			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
+			return loggingConfig.enableMessageDeleteLogs
+		}
+
+		ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED -> {
+			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
+			return loggingConfig.enableMessageDeleteLogs
+		}
+
+		ConfigOptions.MESSAGE_LOG -> {
+			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
+			return loggingConfig.messageChannel != null
+		}
+
+		ConfigOptions.MEMBER_LOGGING_ENABLED -> {
+			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
+			return loggingConfig.enableMemberLogs
+		}
+
+		ConfigOptions.MEMBER_LOG -> {
+			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
+			return loggingConfig.memberLog != null
+		}
+
+		ConfigOptions.LOG_UPLOADS_ENABLED -> {
+			val utilityConfig = UtilityConfigCollection().getConfig(guildId) ?: return false
+			return utilityConfig.disableLogUploading
+		}
+
+		ConfigOptions.UTILITY_LOG -> {
+			val utilityConfig = UtilityConfigCollection().getConfig(guildId) ?: return false
+			return utilityConfig.utilityLogChannel != null
 		}
 	}
 }

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -68,7 +68,7 @@ internal val utilsLogger = KotlinLogging.logger("Checks Logger")
  * @author NoComment1105
  * @since 3.2.0
  */
-suspend inline fun CheckContext<*>.requireConfigs(vararg configOptions: ConfigOptions) {
+suspend inline fun CheckContext<*>.requiredConfigs(vararg configOptions: ConfigOptions) {
 	if (!passed) {
 		return
 	}
@@ -268,12 +268,17 @@ suspend inline fun CheckContext<*>.requireConfigs(vararg configOptions: ConfigOp
 	}
 }
 
+/**
+ * This function checks if a single config exists and is valid. Returns true if it is or false otherwise.
+ *
+ * @param option The config option to check the database for. Only takes a single option.
+ * @return True if the selected [option] is valid and enabled and false if it isn't
+ * @author NoComment1105
+ * @since 3.2.0
+ */
 suspend inline fun configIsUsable(option: ConfigOptions, guildId: Snowflake): Boolean {
 	when (option) {
-		ConfigOptions.SUPPORT_ENABLED -> {
-			val supportConfig = SupportConfigCollection().getConfig(guildId) ?: return false
-			return supportConfig.enabled
-		}
+		ConfigOptions.SUPPORT_ENABLED -> return SupportConfigCollection().getConfig(guildId)?.enabled ?: false
 
 		ConfigOptions.SUPPORT_CHANNEL -> {
 			val supportConfig = SupportConfigCollection().getConfig(guildId) ?: return false
@@ -285,10 +290,7 @@ suspend inline fun configIsUsable(option: ConfigOptions, guildId: Snowflake): Bo
 			return supportConfig.role != null
 		}
 
-		ConfigOptions.MODERATION_ENABLED -> {
-			val moderationConfig = ModerationConfigCollection().getConfig(guildId) ?: return false
-			return moderationConfig.enabled
-		}
+		ConfigOptions.MODERATION_ENABLED -> return ModerationConfigCollection().getConfig(guildId)?.enabled ?: false
 
 		ConfigOptions.MODERATOR_ROLE -> {
 			val moderationConfig = ModerationConfigCollection().getConfig(guildId) ?: return false
@@ -305,25 +307,18 @@ suspend inline fun configIsUsable(option: ConfigOptions, guildId: Snowflake): Bo
 			return moderationConfig.publicLogging != null
 		}
 
-		ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED -> {
-			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
-			return loggingConfig.enableMessageDeleteLogs
-		}
+		ConfigOptions.MESSAGE_DELETE_LOGGING_ENABLED ->
+			return LoggingConfigCollection().getConfig(guildId)?.enableMessageDeleteLogs ?: false
 
-		ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED -> {
-			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
-			return loggingConfig.enableMessageDeleteLogs
-		}
+		ConfigOptions.MESSAGE_EDIT_LOGGING_ENABLED ->
+			return LoggingConfigCollection().getConfig(guildId)?.enableMessageEditLogs ?: false
 
 		ConfigOptions.MESSAGE_LOG -> {
 			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
 			return loggingConfig.messageChannel != null
 		}
 
-		ConfigOptions.MEMBER_LOGGING_ENABLED -> {
-			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false
-			return loggingConfig.enableMemberLogs
-		}
+		ConfigOptions.MEMBER_LOGGING_ENABLED -> return LoggingConfigCollection().getConfig(guildId)?.enableMemberLogs ?: false
 
 		ConfigOptions.MEMBER_LOG -> {
 			val loggingConfig = LoggingConfigCollection().getConfig(guildId) ?: return false

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -387,12 +387,10 @@ suspend inline fun getLoggingChannelWithPerms(channelType: ConfigOptions, guild:
  * @author tempest15
  * @since 3.5.4
  */
-suspend inline fun getFirstUsableChannel(inputGuild: GuildBehavior): GuildMessageChannel? {
-	val channelWithPerms = inputGuild.channels.first {
+suspend inline fun getFirstUsableChannel(inputGuild: GuildBehavior): GuildMessageChannel? =
+	inputGuild.channels.first {
 		it.botHasPermissions(Permission.ViewChannel, Permission.SendMessages)
-	}.asChannelOfOrNull<GuildMessageChannel>()
-	return channelWithPerms
-}
+	}.asChannelOfOrNull()
 
 /**
  * Gets the channel of the event and checks that the bot has the required [permissions].


### PR DESCRIPTION
Resolves #252 

This PR splits the configPresent check in two. It creates a requireConfigs check and a function configIsUsable that returns a boolean. It then adjusts code to make use of this boolean to avoid logging when logging channels are not set.

~~It's not quite done however. Currently, the way the getLoggingChannel function works it returns the commands if a logging channel cannot be found. Once this is fixed, the PR will be marked as ready for review.~~