### PR TITLE
Allow a default repo to be set on the GitHub commands

### DIFF
--- a/docs/commanddocs.toml
+++ b/docs/commanddocs.toml
@@ -271,13 +271,13 @@ description = "The GitHub commands allow users to query GitHub for things such a
 [[command]]
 category = "GitHub commands"
 name = "github issue"
-args = "* `repository` - GitHub repository the issue is in, by the format 'USER-NAME/REPO-NAME' or URL - String\n* `issue-number` - Number of the issue to be searched for - Integer"
+args = "* `issue-number` - Number of the issue to be searched for - Integer\n* `repository` - GitHub repository the issue is in, by the format 'USER-NAME/REPO-NAME' or URL - Optional String"
 result = "An embed containing the information about the queryed issue."
 
 [[command]]
 category = "GitHub commands"
 name = "github repo"
-args = "* `repository` - GitHub repository to be searched for, by the format 'USER-NAME/REPO-NAME' or URL - String"
+args = "* `repository` - GitHub repository to be searched for, by the format 'USER-NAME/REPO-NAME' or URL - Optional String"
 result = "An embed containing the information about the queryed repository"
 
 [[command]]
@@ -285,6 +285,19 @@ category = "Github commands"
 name = "github user"
 args = "* `username` - GitHub user or repository to be searched for, can be a username or URL - String"
 result = "An embed containing the information about the queryed user."
+
+[[command]]
+category = "Github Commands"
+name = "github default-repo"
+args = "* `default-repo` - GitHub repository to be searched for by default, by the format 'USER-NAME/REPO-NAME' or URL - String"
+result = "Stores the default repo and searches that in the other commands when a repository is not provided"
+permissions = "Moderate Members"
+
+[[command]]
+category = "Github Commands"
+name = "github remove-default-repo"
+result = "Removes the default repo for searches using the GitHub commands"
+permissions = "Moderate Members"
 # End GitHub commands
 
 # Tag commands

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -530,8 +530,8 @@ The GitHub commands allow users to query GitHub for things such as issues, pull 
 
 ### Name: `github issue`
 **Arguments**:
-* `repository` - GitHub repository the issue is in, by the format 'USER-NAME/REPO-NAME' or URL - String
 * `issue-number` - Number of the issue to be searched for - Integer
+* `repository` - GitHub repository the issue is in, by the format 'USER-NAME/REPO-NAME' or URL - Optional String
 
 **Result**: An embed containing the information about the queryed issue.
 
@@ -543,7 +543,7 @@ The GitHub commands allow users to query GitHub for things such as issues, pull 
 
 ### Name: `github repo`
 **Arguments**:
-* `repository` - GitHub repository to be searched for, by the format 'USER-NAME/REPO-NAME' or URL - String
+* `repository` - GitHub repository to be searched for, by the format 'USER-NAME/REPO-NAME' or URL - Optional String
 
 **Result**: An embed containing the information about the queryed repository
 
@@ -562,6 +562,30 @@ The GitHub commands allow users to query GitHub for things such as issues, pull 
 **Required Permissions**: `None`
 
 **Command category**: `Github commands`
+
+---
+
+### Name: `github default-repo`
+**Arguments**:
+* `default-repo` - GitHub repository to be searched for by default, by the format 'USER-NAME/REPO-NAME' or URL - String
+
+**Result**: Stores the default repo and searches that in the other commands when a repository is not provided
+
+**Required Permissions**: `Moderate Members`
+
+**Command category**: `Github Commands`
+
+---
+
+### Name: `github remove-default-repo`
+**Arguments**:
+None
+
+**Result**: Removes the default repo for searches using the GitHub commands
+
+**Required Permissions**: `Moderate Members`
+
+**Command category**: `Github Commands`
 
 ---
 

--- a/src/main/kotlin/org/hyacinthbots/lilybot/LilyBot.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/LilyBot.kt
@@ -44,7 +44,7 @@ import org.kohsuke.github.GitHubBuilder
 import java.io.IOException
 import kotlin.io.path.Path
 
-var github: GitHub? = null
+lateinit var github: GitHub
 private val gitHubLogger = KotlinLogging.logger("GitHub Logger")
 
 var commandDocs: CommandDocs? = null

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/Cleanups.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/Cleanups.kt
@@ -11,6 +11,7 @@ import kotlinx.datetime.Clock
 import mu.KotlinLogging
 import org.hyacinthbots.lilybot.database.Cleanups.cleanupGuildData
 import org.hyacinthbots.lilybot.database.Cleanups.cleanupThreadData
+import org.hyacinthbots.lilybot.database.collections.GithubCollection
 import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.database.collections.ModerationConfigCollection
 import org.hyacinthbots.lilybot.database.collections.ReminderCollection
@@ -80,6 +81,7 @@ object Cleanups : KordExKoinComponent {
 				WarnCollection().clearWarns(it.guildId)
 				RoleMenuCollection().removeAllRoleMenus(it.guildId)
 				ReminderCollection().removeGuildReminders(it.guildId)
+				GithubCollection().removeDefaultRepo(it.guildId)
 				guildLeaveTimeCollection.deleteOne(GuildLeaveTimeData::guildId eq it.guildId)
 				deletedGuildData += 1 // Increment the counter for logging
 			}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/collections/GithubCollection.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/collections/GithubCollection.kt
@@ -1,0 +1,58 @@
+package org.hyacinthbots.lilybot.database.collections
+
+import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
+import dev.kord.common.entity.Snowflake
+import org.hyacinthbots.lilybot.database.Database
+import org.hyacinthbots.lilybot.database.entities.GithubData
+import org.koin.core.component.inject
+import org.litote.kmongo.eq
+
+/**
+ * This class contains the functions for interacting with the [GitHub database][GithubData]. This class contains
+ * functions for getting, setting and removing default repos
+ *
+ * @since 4.3.0
+ * @see getDefaultRepo
+ * @see setDefaultRepo
+ * @see removeDefaultRepo
+ */
+class GithubCollection : KordExKoinComponent {
+	private val db: Database by inject()
+
+	@PublishedApi
+	internal val collection = db.mainDatabase.getCollection<GithubData>()
+
+	/**
+	 * Gets the default repo for GitHub commands.
+	 *
+	 * @param inputGuildId The ID of the guild to get the default for
+	 * @return The default repo URL
+	 * @author NoComment1105
+	 * @since 4.3.0
+	 */
+	suspend inline fun getDefaultRepo(inputGuildId: Snowflake): String? =
+		collection.findOne(GithubData::guildId eq inputGuildId)?.defaultRepo
+
+	/**
+	 * Sets the default repo for GitHub commands.
+	 *
+	 * @param inputGuildId The ID of the guild to set the default for
+	 * @param url The URL to set as default
+	 * @author NoComment1105
+	 * @since 4.3.0
+	 */
+	suspend inline fun setDefaultRepo(inputGuildId: Snowflake, url: String) {
+		collection.deleteOne(GithubData::guildId eq inputGuildId)
+		collection.insertOne(GithubData(inputGuildId, url))
+	}
+
+	/**
+	 * Removes the default repo for GitHub commands.
+	 *
+	 * @param inputGuildId The ID of the guild to remove the default for
+	 * @author NoComment1105
+	 * @since 4.3.0
+	 */
+	suspend inline fun removeDefaultRepo(inputGuildId: Snowflake) =
+		collection.deleteOne(GithubData::guildId eq inputGuildId)
+}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/GithubData.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/GithubData.kt
@@ -1,0 +1,16 @@
+package org.hyacinthbots.lilybot.database.entities
+
+import dev.kord.common.entity.Snowflake
+import kotlinx.serialization.Serializable
+
+/**
+ * The data for GitHub commands.
+ *
+ * @property guildId The ID of the guild the data is for
+ * @property defaultRepo The Default Repo to search for issues in
+ */
+@Serializable
+data class GithubData(
+	val guildId: Snowflake,
+	val defaultRepo: String
+)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/Migrator.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/Migrator.kt
@@ -20,6 +20,7 @@ import org.hyacinthbots.lilybot.database.migrations.config.configV1
 import org.hyacinthbots.lilybot.database.migrations.main.mainV1
 import org.hyacinthbots.lilybot.database.migrations.main.mainV2
 import org.hyacinthbots.lilybot.database.migrations.main.mainV3
+import org.hyacinthbots.lilybot.database.migrations.main.mainV4
 import org.koin.core.component.inject
 
 object Migrator : KordExKoinComponent {
@@ -54,6 +55,7 @@ object Migrator : KordExKoinComponent {
 					1 -> ::mainV1
 					2 -> ::mainV2
 					3 -> ::mainV3
+					4 -> ::mainV4
 					else -> break
 				}(db.mainDatabase)
 

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/main/mainV4.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/main/mainV4.kt
@@ -1,0 +1,7 @@
+package org.hyacinthbots.lilybot.database.migrations.main
+
+import org.litote.kmongo.coroutine.CoroutineDatabase
+
+suspend fun mainV4(db: CoroutineDatabase) {
+	db.createCollection("githubData")
+}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
@@ -56,6 +56,7 @@ import dev.kord.rest.request.KtorRequestException
 import kotlinx.coroutines.flow.toList
 import kotlinx.datetime.Clock
 import org.hyacinthbots.lilybot.database.collections.GalleryChannelCollection
+import org.hyacinthbots.lilybot.database.collections.GithubCollection
 import org.hyacinthbots.lilybot.database.collections.LogUploadingBlacklistCollection
 import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.database.collections.ModerationConfigCollection
@@ -504,6 +505,7 @@ class ModUtilities : Extension() {
 								SupportConfigCollection().clearConfig(guild!!.id)
 								UtilityConfigCollection().clearConfig(guild!!.id)
 								GalleryChannelCollection().removeAll(guild!!.id)
+								GithubCollection().removeDefaultRepo(guild!!.id)
 								LogUploadingBlacklistCollection().clearBlacklist(guild!!.id)
 								ReminderCollection().removeGuildReminders(guild!!.id)
 								RoleMenuCollection().removeAllRoleMenus(guild!!.id)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -36,6 +36,7 @@ import mu.KotlinLogging
 import org.hyacinthbots.lilybot.database.Database
 import org.hyacinthbots.lilybot.database.collections.ConfigMetaCollection
 import org.hyacinthbots.lilybot.database.collections.GalleryChannelCollection
+import org.hyacinthbots.lilybot.database.collections.GithubCollection
 import org.hyacinthbots.lilybot.database.collections.GuildLeaveTimeCollection
 import org.hyacinthbots.lilybot.database.collections.LoggingConfigCollection
 import org.hyacinthbots.lilybot.database.collections.MainMetaCollection
@@ -572,6 +573,7 @@ suspend inline fun ExtensibleBotBuilder.database(migrate: Boolean) {
 				single { LoggingConfigCollection() } bind LoggingConfigCollection::class
 				single { UtilityConfigCollection() } bind UtilityConfigCollection::class
 				single { GalleryChannelCollection() } bind GalleryChannelCollection::class
+				single { GithubCollection() } bind GithubCollection::class
 				single { GuildLeaveTimeCollection() } bind GuildLeaveTimeCollection::class
 				single { MainMetaCollection() } bind MainMetaCollection::class
 				single { ConfigMetaCollection() } bind ConfigMetaCollection::class


### PR DESCRIPTION
Fixes #230

Allows a default repository to be searched when using the GitHub commands. Of course, you can still search for your own repository, the option is just `optional` now.