### PR TITLE
Remove warn: use actual number of strikes

### DIFF
--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -580,7 +580,7 @@ class TemporaryModeration : Extension() {
 						return@action
 					}
 
-					everyofneRole.edit {
+					everyoneRole.edit {
 						permissions = everyoneRole.permissions
 							.minus(Permission.SendMessages)
 							.minus(Permission.SendMessagesInThreads)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -311,7 +311,7 @@ class TemporaryModeration : Extension() {
 				}
 
 				WarnCollection().setWarn(userArg.id, guild!!.id, true)
-				val newStrikes = WarnCollection().getWarn(userArg.id, guild!!.id).strikes
+				val newStrikes = WarnCollection().getWarn(userArg.id, guild!!.id)!!.strikes
 
 				respond {
 					content = "Removed strike from user"

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -311,7 +311,7 @@ class TemporaryModeration : Extension() {
 				}
 
 				WarnCollection().setWarn(userArg.id, guild!!.id, true)
-				val newStrikes = WarnCollection().getWarn(userArg.id, guild!!.id)
+				val newStrikes = WarnCollection().getWarn(userArg.id, guild!!.id).strikes
 
 				respond {
 					content = "Removed strike from user"
@@ -580,7 +580,7 @@ class TemporaryModeration : Extension() {
 						return@action
 					}
 
-					everyoneRole.edit {
+					everyofneRole.edit {
 						permissions = everyoneRole.permissions
 							.minus(Permission.SendMessages)
 							.minus(Permission.SendMessagesInThreads)


### PR DESCRIPTION
The previous code passed around a `WarnData` for formatting. This PR makes sure to look up its `.strikes` attribute.
