### PR TITLE
Additional permission checks

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kord-extensions = "1.5.5-20221121.113710-37"
+kord-extensions = "1.5.5-20221205.192723-47"
 logging = "3.0.4"
 logback = "1.4.5"
 github-api = "1.313"

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
@@ -67,6 +67,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 
 		initialResponse = InitialSlashCommandResponse.None
 
+		requirePermission(Permission.ManageGuild)
+
 		check {
 			anyGuild()
 			hasPermission(Permission.ManageGuild)
@@ -223,6 +225,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 		name = "moderation"
 		description = "Configure Lily's moderation system"
 
+		requirePermission(Permission.ManageGuild)
+
 		check {
 			anyGuild()
 			hasPermission(Permission.ManageGuild)
@@ -362,6 +366,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 		name = "logging"
 		description = "Configure Lily's logging system"
 
+		requirePermission(Permission.ManageGuild)
+
 		check {
 			anyGuild()
 			hasPermission(Permission.ManageGuild)
@@ -479,6 +485,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 		name = "utility"
 		description = "Configure Lily's utility settings"
 
+		requirePermission(Permission.ManageGuild)
+
 		check {
 			anyGuild()
 			hasPermission(Permission.ManageGuild)
@@ -557,6 +565,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 	ephemeralSubCommand(::ClearArgs) {
 		name = "clear"
 		description = "Clear a config type"
+
+		requirePermission(Permission.ManageGuild)
 
 		check {
 			anyGuild()
@@ -698,6 +708,8 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 	ephemeralSubCommand(::ViewArgs) {
 		name = "view"
 		description = "View the current config that you have set"
+
+		requirePermission(Permission.ManageGuild)
 
 		check {
 			anyGuild()

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/LogUploading.kt
@@ -282,6 +282,8 @@ class LogUploading : Extension() {
 			name = "log-uploading"
 			description = "The parent command for blacklisting channels from running the log uploading code"
 
+			requirePermission(Permission.ModerateMembers)
+
 			check {
 				anyGuild()
 				hasPermission(Permission.ModerateMembers)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/events/LogUploading.kt
@@ -282,16 +282,16 @@ class LogUploading : Extension() {
 			name = "log-uploading"
 			description = "The parent command for blacklisting channels from running the log uploading code"
 
-			requirePermission(Permission.ModerateMembers)
-
-			check {
-				anyGuild()
-				hasPermission(Permission.ModerateMembers)
-			}
-
 			ephemeralSubCommand {
 				name = "blacklist-add"
 				description = "Add a channel to the log uploading blacklist"
+
+				requirePermission(Permission.ModerateMembers)
+
+				check {
+					anyGuild()
+					hasPermission(Permission.ModerateMembers)
+				}
 
 				action {
 					val blacklist = LogUploadingBlacklistCollection().isChannelInUploadBlacklist(guild!!.id, channel.id)
@@ -328,6 +328,13 @@ class LogUploading : Extension() {
 				name = "blacklist-remove"
 				description = "Remove a channel from the log uploading blacklist"
 
+				requirePermission(Permission.ModerateMembers)
+
+				check {
+					anyGuild()
+					hasPermission(Permission.ModerateMembers)
+				}
+
 				action {
 					LogUploadingBlacklistCollection().isChannelInUploadBlacklist(guild!!.id, channel.id) ?: run {
 						respond {
@@ -361,6 +368,13 @@ class LogUploading : Extension() {
 			ephemeralSubCommand {
 				name = "blacklist-list"
 				description = "List all channels that block log uploading"
+
+				requirePermission(Permission.ModerateMembers)
+
+				check {
+					anyGuild()
+					hasPermission(Permission.ModerateMembers)
+				}
 
 				action {
 					var channels = ""

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/LockingCommands.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/LockingCommands.kt
@@ -43,6 +43,8 @@ class LockingCommands : Extension() {
 				name = "channel"
 				description = "Lock a channel so those with default permissions cannot send messages"
 
+				requirePermission(Permission.ModerateMembers)
+
 				check {
 					anyGuild()
 					requiredConfigs(
@@ -111,6 +113,8 @@ class LockingCommands : Extension() {
 				name = "server"
 				description = "Lock the server so those with default permissions cannot send messages"
 
+				requirePermission(Permission.ModerateMembers)
+
 				check {
 					anyGuild()
 					requiredConfigs(
@@ -171,6 +175,8 @@ class LockingCommands : Extension() {
 			ephemeralSubCommand(::UnlockChannelArgs) {
 				name = "channel"
 				description = "Unlock a channel so everyone can send messages again"
+
+				requirePermission(Permission.ModerateMembers)
 
 				check {
 					anyGuild()
@@ -242,6 +248,8 @@ class LockingCommands : Extension() {
 			ephemeralSubCommand {
 				name = "server"
 				description = "Unlock the server so everyone can send messages again"
+
+				requirePermission(Permission.ModerateMembers)
 
 				check {
 					anyGuild()

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/ModerationCommands.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/ModerationCommands.kt
@@ -6,6 +6,7 @@ import com.kotlindiscord.kord.extensions.DISCORD_RED
 import com.kotlindiscord.kord.extensions.annotations.DoNotChain
 import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.checks.hasPermission
+import com.kotlindiscord.kord.extensions.checks.hasPermissions
 import com.kotlindiscord.kord.extensions.checks.types.CheckContextWithCache
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.impl.coalescingOptionalDuration
@@ -86,10 +87,10 @@ class ModerationCommands : Extension() {
 			name = "Moderate"
 			locking = true
 
+			requirePermission(Permission.BanMembers, Permission.KickMembers, Permission.ModerateMembers)
+
 			check {
-				hasPermission(Permission.BanMembers) // TODO Go make a `hasPermissions` in KordEx. **Edit: PR Submitted**
-				hasPermission(Permission.KickMembers)
-				hasPermission(Permission.ModerateMembers)
+				hasPermissions(Permissions(Permission.BanMembers, Permission.KickMembers, Permission.ModerateMembers))
 				requireBotPermissions(Permission.BanMembers, Permission.KickMembers, Permission.ModerateMembers)
 			}
 
@@ -448,6 +449,8 @@ class ModerationCommands : Extension() {
 			name = "ban"
 			description = "Bans a user."
 
+			requirePermission(Permission.BanMembers)
+
 			check {
 				modCommandChecks(Permission.BanMembers)
 				requireBotPermissions(Permission.BanMembers)
@@ -510,6 +513,8 @@ class ModerationCommands : Extension() {
 		ephemeralSlashCommand(::SoftBanArgs) {
 			name = "soft-ban"
 			description = "Soft-bans a user."
+
+			requirePermission(Permission.BanMembers)
 
 			check {
 				modCommandChecks(Permission.BanMembers)
@@ -576,6 +581,8 @@ class ModerationCommands : Extension() {
 			name = "unban"
 			description = "Unbans a user."
 
+			requirePermission(Permission.BanMembers)
+
 			check {
 				modCommandChecks(Permission.BanMembers)
 				requireBotPermissions(Permission.BanMembers)
@@ -622,6 +629,8 @@ class ModerationCommands : Extension() {
 		ephemeralSlashCommand(::KickArgs) {
 			name = "kick"
 			description = "Kicks a user."
+
+			requirePermission(Permission.KickMembers)
 
 			check {
 				modCommandChecks(Permission.KickMembers)
@@ -674,6 +683,8 @@ class ModerationCommands : Extension() {
 			name = "clear"
 			description = "Clears messages from a channel."
 
+			requirePermission(Permission.ManageMessages)
+
 			check {
 				modCommandChecks(Permission.ManageMessages)
 				requireBotPermissions(Permission.ManageMessages)
@@ -719,6 +730,8 @@ class ModerationCommands : Extension() {
 		ephemeralSlashCommand(::TimeoutArgs) {
 			name = "timeout"
 			description = "Times out a user."
+
+			requirePermission(Permission.ModerateMembers)
 
 			check {
 				modCommandChecks(Permission.ModerateMembers)
@@ -783,6 +796,8 @@ class ModerationCommands : Extension() {
 			name = "remove-timeout"
 			description = "Removes a timeout from a user"
 
+			requirePermission(Permission.ModerateMembers)
+
 			check {
 				modCommandChecks(Permission.ModerateMembers)
 				requireBotPermissions(Permission.ModerateMembers)
@@ -827,6 +842,8 @@ class ModerationCommands : Extension() {
 		ephemeralSlashCommand(::WarnArgs) {
 			name = "warn"
 			description = "Warns a user."
+
+			requirePermission(Permission.ModerateMembers)
 
 			check {
 				modCommandChecks(Permission.ModerateMembers)
@@ -962,6 +979,8 @@ class ModerationCommands : Extension() {
 		ephemeralSlashCommand(::RemoveWarnArgs) {
 			name = "remove-warn"
 			description = "Removes a user's warnings"
+
+			requirePermission(Permission.ModerateMembers)
 
 			check {
 				modCommandChecks(Permission.ModerateMembers)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/GalleryChannel.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/GalleryChannel.kt
@@ -51,6 +51,8 @@ class GalleryChannel : Extension() {
 				name = "set"
 				description = "Set a channel as a gallery channel"
 
+				requirePermission(Permission.ManageGuild)
+
 				check {
 					anyGuild()
 					hasPermission(Permission.ManageGuild)
@@ -94,6 +96,8 @@ class GalleryChannel : Extension() {
 			ephemeralSubCommand {
 				name = "unset"
 				description = "Unset a channel as a gallery channel."
+
+				requirePermission(Permission.ManageGuild)
 
 				check {
 					anyGuild()

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Github.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Github.kt
@@ -523,6 +523,8 @@ class Github : Extension() {
 				name = "default-repo"
 				description = "Set the default repo to look up issues in."
 
+				requirePermission(Permission.ModerateMembers)
+
 				check {
 					anyGuild()
 					hasPermission(Permission.ModerateMembers)
@@ -565,6 +567,8 @@ class Github : Extension() {
 			ephemeralSubCommand {
 				name = "remove-default-repo"
 				description = "Removes the default repo for this guild"
+
+				requirePermission(Permission.ModerateMembers)
 
 				check {
 					anyGuild()

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/GuildAnnouncements.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/GuildAnnouncements.kt
@@ -40,6 +40,7 @@ class GuildAnnouncements : Extension() {
 			initialResponse = InitialSlashCommandResponse.None
 
 			guild(TEST_GUILD_ID)
+			requirePermission(Permission.Administrator)
 
 			check {
 				hasPermission(Permission.Administrator)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/ModUtilities.kt
@@ -97,6 +97,8 @@ class ModUtilities : Extension() {
 			name = "say"
 			description = "Say something through Lily."
 
+			requirePermission(Permission.ModerateMembers)
+
 			check {
 				anyGuild()
 				hasPermission(Permission.ModerateMembers)
@@ -188,6 +190,8 @@ class ModUtilities : Extension() {
 		ephemeralSlashCommand(::SayEditArgs) {
 			name = "edit-say"
 			description = "Edit a message created by /say"
+
+			requirePermission(Permission.ModerateMembers)
 
 			check {
 				anyGuild()
@@ -358,7 +362,9 @@ class ModUtilities : Extension() {
 			ephemeralSubCommand(::PresenceArgs) {
 				name = "set"
 				description = "Set a custom status for Lily."
+
 				guild(TEST_GUILD_ID)
+				requirePermission(Permission.Administrator)
 
 				check {
 					hasPermission(Permission.Administrator)
@@ -395,7 +401,9 @@ class ModUtilities : Extension() {
 			ephemeralSubCommand {
 				name = "reset"
 				description = "Reset Lily's presence to the default status."
+
 				guild(TEST_GUILD_ID)
+				requirePermission(Permission.Administrator)
 
 				check {
 					hasPermission(Permission.Administrator)

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Reminders.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Reminders.kt
@@ -325,11 +325,7 @@ class Reminders : Extension() {
 				name = "mod-list"
 				description = "List all reminders for a user, if you're a moderator"
 
-				check {
-					anyGuild()
-					hasPermission(Permission.ModerateMembers)
-					requirePermission(Permission.ModerateMembers)
-				}
+				requirePermission(Permission.ModerateMembers)
 
 				check {
 					anyGuild()
@@ -357,6 +353,14 @@ class Reminders : Extension() {
 			ephemeralSubCommand(::ReminderModRemoveArgs) {
 				name = "mod-remove"
 				description = "Remove a reminder for a user, if you're a moderator"
+
+				requirePermission(Permission.ModerateMembers)
+
+				check {
+					anyGuild()
+					hasPermission(Permission.ModerateMembers)
+					requirePermission(Permission.ModerateMembers)
+				}
 
 				action {
 					val reminders = ReminderCollection().getRemindersForUser(arguments.user.id)
@@ -396,6 +400,8 @@ class Reminders : Extension() {
 			ephemeralSubCommand(::ReminderModRemoveAllArgs) {
 				name = "mod-remove-all"
 				description = "Remove all a specific type of reminder for a user, if you're a moderator"
+
+				requirePermission(Permission.ModerateMembers)
 
 				check {
 					anyGuild()

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/RoleMenu.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/RoleMenu.kt
@@ -68,6 +68,8 @@ class RoleMenu : Extension() {
 				name = "create"
 				description = "Create a new role menu in this channel. A channel can have any number of role menus."
 
+				requirePermission(Permission.ManageRoles)
+
 				check {
 					anyGuild()
 					hasPermission(Permission.ManageRoles)
@@ -167,6 +169,8 @@ class RoleMenu : Extension() {
 				name = "add"
 				description = "Add a role to the existing role menu in this channel."
 
+				requirePermission(Permission.ManageRoles)
+
 				check {
 					anyGuild()
 					hasPermission(Permission.ManageRoles)
@@ -241,6 +245,8 @@ class RoleMenu : Extension() {
 				name = "remove"
 				description = "Remove a role from the existing role menu in this channel."
 
+				requirePermission(Permission.ManageMessages)
+
 				check {
 					anyGuild()
 					hasPermission(Permission.ManageMessages)
@@ -304,6 +310,8 @@ class RoleMenu : Extension() {
 			ephemeralSubCommand {
 				name = "pronouns"
 				description = "Create a pronoun selection role menu and the roles to go with it."
+
+				requirePermission(Permission.ManageMessages)
 
 				check {
 					anyGuild()

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Tags.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/util/Tags.kt
@@ -235,6 +235,8 @@ class Tags : Extension() {
 			name = "tag-create"
 			description = "Create a tag for your guild! Use /tag-help for more info."
 
+			requirePermission(Permission.ModerateMembers)
+
 			check {
 				anyGuild()
 				hasPermission(Permission.ModerateMembers)
@@ -306,6 +308,8 @@ class Tags : Extension() {
 			name = "tag-delete"
 			description = "Delete a tag from your guild. Use /tag-help for more info."
 
+			requirePermission(Permission.ModerateMembers)
+
 			check {
 				anyGuild()
 				hasPermission(Permission.ModerateMembers)
@@ -343,6 +347,8 @@ class Tags : Extension() {
 		ephemeralSlashCommand(::EditTagArgs) {
 			name = "tag-edit"
 			description = "Edit a tag in your guild. Use /tag-help for more info."
+
+			requirePermission(Permission.ModerateMembers)
 
 			check {
 				anyGuild()


### PR DESCRIPTION
Registers a default permission required for the commands. The ones in the check block are still required for proper security. This also helps doc-gen read permissions properly