### PR TITLE
Fix auto-punishment based on warn command

### DIFF
--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/ModerationCommands.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/ModerationCommands.kt
@@ -906,7 +906,7 @@ class ModerationCommands : Extension() {
 					dm = arguments.userArgument.dm {
 						embed {
 							title = "Warning $strikes in $guildName"
-							description = "**Reason:** ${arguments.reason}\n\n" + warnText
+							description = "**Reason:** ${arguments.reason}\n\n$warnText"
 						}
 					}
 				}


### PR DESCRIPTION
### Proposed Changes

The Duration string on warning timeouts was incorrect for the 3 day timeout, so was erroring. This has been fixed.
If quick-warnings were issued through the menu system, punishments are now applied (if the config says so). Previously it just didn't try.
The logs for quick-warnings and /warn were formatted very differently, so have been made consistent.