### PR TITLE
Allow multiple roles to be pinged on auto-threads

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,22 +38,69 @@ None
 	* `channel` - The channel to view the auto-threading settings for. - Channel
 
 ---
-#### Command name: `auto-threading add-roles`
+### Command name: `auto-threading add-roles`
 **Description**: Add extra to threads in auto-threaded channels
-**Additional Information**:This command will add roles to be pinged alongside the default ping role for this auto-threaded channel
-Required Member Permissions: Manage Channels
+
+**Additional Information**: This command will add roles to be pinged alongside the default ping role for this auto-threaded channel
+
+**Required Member Permissions**: Manage Channels
 
 * **Arguments**:
 	* `role` - A role to invite to threads in this channel - Optional Role
 
 ---
-#### Command name: `auto-threading remove-roles`
+### Command name: `auto-threading remove-roles`
 **Description**: Remove extra from threads in auto-threaded channels
-**Additional Information**:This command will remove roles that have been added to be pinged alongside the default ping role for this auto-threaded channel
-Required Member Permissions: Manage Channels
+
+**Additional Information**: This command will remove roles that have been added to be pinged alongside the default ping role for this auto-threaded channel
+
+**Required Member Permissions**: Manage Channels
 
 * **Arguments**:
 	* `role` - A role to invite to threads in this channel - Optional Role
+
+---
+### Command name: `clear count`
+**Description**: Clear a specific count of messages
+
+**Required Member Permissions**: Manage Messages
+
+* **Arguments**:
+	* `messages` - Number of messages to delete - Int
+	* `author` - The author of the messages to clear - Optional User
+
+---
+### Command name: `clear before`
+**Description**: Clear messages before a given message ID
+
+**Required Member Permissions**: Manage Messages
+
+* **Arguments**:
+	* `before` - The ID of the message to clear before - Snowflake
+	* `message-count` - The number of messages to clear - Optional Int/Long
+	* `author` - The author of the messages to clear - Optional User
+
+---
+### Command name: `clear after`
+**Description**: Clear messages before a given message ID
+
+**Required Member Permissions**: Manage Messages
+
+* **Arguments**:
+	* `after` - The ID of the message to clear after - Snowflake
+	* `message-count` - The number of messages to clear - Optional Int/Long
+	* `author` - The author of the messages to clear - Optional User
+
+---
+### Command name: `clear between`
+**Description**: Clear messages between 2 message IDs
+
+**Required Member Permissions**: Manage Messages
+
+* **Arguments**:
+	* `after` - The ID of the message to clear after - Snowflake
+	* `before` - The ID of the message to clear before - Snowflake
+	* `author` - The author of the messages to clear - Optional User
 
 ---
 ### Command name: `config moderation`
@@ -335,49 +382,6 @@ None
 	* `reason` - The reason for the Kick - Defaulting String
 	* `dm` - Whether to send a direct message to the user about the kick - Defaulting Boolean
 	* `image` - An image you'd like to provide as extra context for the action - Optional Attachment
-
----
-### Command name: `clear count`
-**Description**: Clear a specific count of messages
-
-**Required Member Permissions**: Manage Messages
-
-* **Arguments**:
-	* `messages` - Number of messages to delete - Int
-	* `author` - The author of the messages to clear - Optional User
-
----
-### Command name: `clear before`
-**Description**: Clear messages before a given message ID
-
-**Required Member Permissions**: Manage Messages
-
-* **Arguments**:
-	* `before` - The ID of the message to clear before - Snowflake
-	* `message-count` - The number of messages to clear - Optional Int/Long
-	* `author` - The author of the messages to clear - Optional User
-
----
-### Command name: `clear after`
-**Description**: Clear messages before a given message ID
-
-**Required Member Permissions**: Manage Messages
-
-* **Arguments**:
-	* `after` - The ID of the message to clear after - Snowflake
-	* `message-count` - The number of messages to clear - Optional Int/Long
-	* `author` - The author of the messages to clear - Optional User
-
----
-### Command name: `clear between`
-**Description**: Clear messages between 2 message IDs
-
-**Required Member Permissions**: Manage Messages
-
-* **Arguments**:
-	* `after` - The ID of the message to clear after - Snowflake
-	* `before` - The ID of the message to clear before - Snowflake
-	* `author` - The author of the messages to clear - Optional User
 
 ---
 ### Command name: `timeout`
@@ -735,8 +739,8 @@ None
 	* `clear` - Whether to clear the channel before repopulating it - Defaulting Boolean
 
 ---
-### Command name: `phishing-check`
-**Description**: Check whether a given domain is a known phishing domain.
+### Command name: `url-safety-check`
+**Description**: Check whether a given domain is a known unsafe domain.
 
 * Arguments:
 	* `domain` - Domain to check - String
@@ -785,7 +789,7 @@ None
 ### Message Command: `Report`
 
 ---
-### Message Command: `Phishing Check`
+### Message Command: `URL Safety Check`
 
 ---
 ## User Commands

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,24 @@ Required Member Permissions: Manage Channels
 	* `channel` - The channel to view the auto-threading settings for. - Channel
 
 ---
+#### Command name: `auto-threading add-roles`
+**Description**: Add extra to threads in auto-threaded channels
+**Additional Information**:This command will add roles to be pinged alongside the default ping role for this auto-threaded channel
+Required Member Permissions: Manage Channels
+
+* **Arguments**:
+	* `role` - A role to invite to threads in this channel - Optional Role
+
+---
+#### Command name: `auto-threading remove-roles`
+**Description**: Remove extra from threads in auto-threaded channels
+**Additional Information**:This command will remove roles that have been added to be pinged alongside the default ping role for this auto-threaded channel
+Required Member Permissions: Manage Channels
+
+* **Arguments**:
+	* `role` - A role to invite to threads in this channel - Optional Role
+
+---
 #### Command name: `config moderation`
 **Description**: Configure Lily's moderation system
 Required Member Permissions: Manage Server

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/collections/AutoThreadingCollection.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/collections/AutoThreadingCollection.kt
@@ -6,6 +6,7 @@ import org.hyacinthbots.lilybot.database.Database
 import org.hyacinthbots.lilybot.database.entities.AutoThreadingData
 import org.koin.core.component.inject
 import org.litote.kmongo.eq
+import org.litote.kmongo.setValue
 
 /**
  * This class contains the functions for interacting with the [AutoThreading Database][AutoThreadingData]. This
@@ -56,6 +57,21 @@ class AutoThreadingCollection : KordExKoinComponent {
 	suspend inline fun setAutoThread(inputAutoThreadData: AutoThreadingData) {
 		collection.deleteOne(AutoThreadingData::channelId eq inputAutoThreadData.channelId)
 		collection.insertOne(inputAutoThreadData)
+	}
+
+	/**
+	 * Updates the extra roles on an auto-threaded channel.
+	 *
+	 * @param inputChannelId The channel to update extra roles for
+	 * @param newRoleIds The new list of role IDs to set
+	 * @author NoComment1105
+	 * @since 5.0.0
+	 */
+	suspend inline fun updateExtraRoles(inputChannelId: Snowflake, newRoleIds: List<Snowflake?>) {
+		collection.updateOne(
+			AutoThreadingData::channelId eq inputChannelId,
+			setValue(AutoThreadingData::extraRoleIds, newRoleIds)
+			)
 	}
 
 	/**

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/AutoThreadingData.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/AutoThreadingData.kt
@@ -28,5 +28,6 @@ data class AutoThreadingData(
 	val contentAwareNaming: Boolean,
 	val mention: Boolean,
 	val creationMessage: String?,
-	val addModsAndRole: Boolean
+	val addModsAndRole: Boolean,
+	val extraRoleIds: MutableList<Snowflake>
 )

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/Migrator.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/Migrator.kt
@@ -26,6 +26,7 @@ import org.hyacinthbots.lilybot.database.migrations.config.configV5
 import org.hyacinthbots.lilybot.database.migrations.config.configV6
 import org.hyacinthbots.lilybot.database.migrations.config.configV7
 import org.hyacinthbots.lilybot.database.migrations.main.mainV1
+import org.hyacinthbots.lilybot.database.migrations.main.mainV10
 import org.hyacinthbots.lilybot.database.migrations.main.mainV2
 import org.hyacinthbots.lilybot.database.migrations.main.mainV3
 import org.hyacinthbots.lilybot.database.migrations.main.mainV4
@@ -73,6 +74,7 @@ object Migrator : KordExKoinComponent {
 					7 -> ::mainV7
 					8 -> ::mainV8
 					9 -> ::mainV9
+					10 -> ::mainV10
 					else -> break
 				}(db.mainDatabase)
 

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/main/mainV10.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/main/mainV10.kt
@@ -1,0 +1,12 @@
+package org.hyacinthbots.lilybot.database.migrations.main
+
+import org.hyacinthbots.lilybot.database.entities.AutoThreadingData
+import org.litote.kmongo.coroutine.CoroutineDatabase
+import org.litote.kmongo.exists
+import org.litote.kmongo.setValue
+
+suspend fun mainV10(db: CoroutineDatabase) {
+	with(db.getCollection<AutoThreadingData>()) {
+		updateMany(AutoThreadingData::extraRoleIds exists false, setValue(AutoThreadingData::extraRoleIds, emptyList()))
+	}
+}


### PR DESCRIPTION
This PR is a soloution to #358 

It adds two commands, one to add roles to ping, one to remove roles to ping. The roles are stored in a Mutable List in the Database in a new field that is added.